### PR TITLE
Fix Floating IP race

### DIFF
--- a/stack-single.yml
+++ b/stack-single.yml
@@ -295,6 +295,7 @@ resources:
 
   manager_floating_ip:
     type: OS::Neutron::FloatingIP
+    depends_on: router_interface
     properties:
       floating_network_id: {get_param: public}
       port_id: {get_resource: manager_port_management}

--- a/stack.yml
+++ b/stack.yml
@@ -500,6 +500,7 @@ resources:
 
   manager_floating_ip:
     type: OS::Neutron::FloatingIP
+    depends_on: router_interface
     properties:
       floating_network_id: {get_param: public}
       port_id: {get_resource: manager_port_management}

--- a/templates/stack.yml.j2
+++ b/templates/stack.yml.j2
@@ -503,6 +503,7 @@ resources:
 
   manager_floating_ip:
     type: OS::Neutron::FloatingIP
+    depends_on: router_interface
     properties:
       floating_network_id: {get_param: public}
       port_id: {get_resource: manager_port_management}


### PR DESCRIPTION
Add dependency of FIP to router interface.

The manager floating ip needs to be associated with a fixed IP address
that is L3 reachable from the public network that we allocate the FIP
from. neutron rightly enforces it, the heat template correctly attaches
the subnet to the router but it misses the dependency, so we hit a race.

Adding a depency fixes it and makes the deployment succeed on CityCloud.