### PR TITLE
Set operator password

### DIFF
--- a/environments/secrets.yml
+++ b/environments/secrets.yml
@@ -11,3 +11,6 @@ ara_password: S6JE2yJUwvraiX57
 ara_server_mariadb_password: dFMWEEARUWSeTNPb
 
 keystone_admin_password: pYV8bV749aDMXLPlYJwoJs4ouRPWezCIOXYAQP6v
+
+# mkpasswd --method=sha-512 -- da5pahthaew2Pai2
+operator_password: $6$F85B6ATMhK$dM/L7cNfboQKaypHLHREbqlSpIEoK7XFlzYMnwqieOCMhERKL931lJxbXytH4olRDvMB4rpl/Dz9CZfXtom8J1


### PR DESCRIPTION
Necessary for the use of Cockpit. A login from outside
on the manager via SSH is not possible because the
password authentication is disabled.