### PR TITLE
Testbed cb 20200304

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+# Makefile
+# Common operations
+default: stack.yml stack-single.yml
+
+STACKNAME = testbed
+
+stack.yml: templates/stack.yml.j2
+	jinja2 -o $@ $^
+
+stack-single.yml: templates/stack.yml.j2
+	jinja2 -o $@ -Dnumber_of_nodes=0 $^
+
+deploy: stack.yml environment.yml
+	@touch .deploy.$(STACKNAME)
+	openstack stack create -t $< -e environment.yml $(STACK_PARAMS) $(STACKNAME)
+
+deploy-infra: stack.yml environment.yml
+	@touch .deploy.$(STACKNAME)
+	openstack stack create -t $< -e environment.yml $(STACK_PARAMS) --parameter deploy_infrastructure=true $(STACKNAME)
+
+deploy-infra-ceph: stack.yml environment.yml
+	@touch .deploy.$(STACKNAME)
+	openstack stack create -t $< -e environment.yml $(STACK_PARAMS) --parameter deploy_infrastructure=true --parameter deploy_ceph=true $(STACKNAME)
+
+deploy-infra-ceph-openstack: stack.yml environment.yml
+	@touch .deploy.$(STACKNAME)
+	openstack stack create -t $< -e environment.yml $(STACK_PARAMS) --parameter deploy_infrastructure=true --parameter deploy_ceph=true --parameter deploy_openstack=true $(STACKNAME)
+
+clean:
+	openstack stack delete -y $(STACKNAME)
+	@rm -f .deploy.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
+	rm -f ~/.ssh/id_rsa.$(STACKNAME)
+
+watch: .deploy.$(STACKNAME)
+	MGR_ADR=""; STAT=""; while true; do\
+		date; openstack stack list; \
+		SRV=$$(openstack server list -f value -c "Name" -c "Status" | grep testbed-manager | cut -d ' ' -f2); \
+		openstack server list; \
+		if test -z "$$MGR_ADR" -a "$$SRV" = "ACTIVE"; then \
+			openstack stack output show $(STACKNAME) private_key -f value -c output_value > ~/.ssh/id_rsa.testbed; \
+			chmod 0600 ~/.ssh/id_rsa.testbed; \
+			MGR_ADR=$$(openstack stack output show $(STACKNAME) manager_address -f value -c output_value); \
+			echo "MANAGER_ADDRESS=$$MGR_ADR" > .MANAGER_ADDRESS.$(STACKNAME); \
+		fi; \
+		if test -n "$$MGR_ADR"; then ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa.testbed ubuntu@$$MGR_ADR "sudo tail -n16 /var/log/cloud-init-output.log"; fi; \
+		STAT=$$(openstack stack list -f value -c "Stack Name" -c "Stack Status" | grep $(STACKNAME) | cut -d' ' -f2); \
+		if test "$$STAT" == "CREATE_COMPLETE"; then break; fi; \
+		if test "$$STAT" == "CREATE_FAILED"; then openstack stack show $(STACKNAME) -f value -c "stack_status_reason"; break; fi; \
+		echo; sleep 30; \
+	done
+
+
+.deploy.$(STACKNAME):
+	STAT=$$(openstack stack list -f value -c "Stack Name" -c "Stack Status" | grep $(STACKNAME) | cut -d' ' -f2); \
+	if test -n "$$STAT"; then touch .deploy.$(STACKNAME); else echo "use make deploy or deploy-infra or ...."; exit 1; fi
+
+~/.ssh/id_rsa.$(STACKNAME): .deploy.$(STACKNAME)
+	openstack stack output show $(STACKNAME) private_key -f value -c output_value > $@
+	chmod 0600 $@
+
+.MANAGER_ADDRESS.$(STACKNAME): .deploy.$(STACKNAME)
+	@MANAGER_ADDRESS=$$(openstack stack output show $(STACKNAME) manager_address -f value -c output_value); \
+	echo "MANAGER_ADDRESS=$$MANAGER_ADDRESS" > $@; \
+	echo $$MANAGER_ADDRESS
+
+sshuttle: ~/.ssh/id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
+	eval $$(ssh-agent); ssh-add $<; \
+	source ./.MANAGER_ADDRESS.$(STACKNAME); \
+	sshuttle dragon@$$MANAGER_ADDRESS 192.168.40.0/24 192.168.50.0/24 192.168.90.0/24
+
+ssh_manager: ~/.ssh/id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
+	source ./.MANAGER_ADDRESS.$(STACKNAME); \
+	ssh -i $< dragon@$$MANAGER_ADDRESS
+
+.PHONY: clean watch sshuttle ssh_manager deploy deploy-infra deploy-infra-ceph deploy-infra-ceph-openstack

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ stack-single.yml: templates/stack.yml.j2
 	jinja2 -o $@ $(TMPL_PARAMS) -Dnumber_of_nodes=0 $^
 
 dry-run: stack.yml environment.yml
-	openstack stack create --dry-run -t $< -e environment.yml $(STACK_PARAMS) $(STACKNAME)
+	openstack stack create --dry-run -t $< -e environment.yml $(STACK_PARAMS) $(STACKNAME) -f json; echo
 
 deploy: stack.yml environment.yml
 	@touch .deploy.$(STACKNAME)

--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,19 @@ stack-single.yml: templates/stack.yml.j2
 
 deploy: stack.yml environment.yml
 	@touch .deploy.$(STACKNAME)
-	openstack stack create -t $< -e environment.yml $(STACK_PARAMS) $(STACKNAME)
+	openstack stack create --timeout 3000 -t $< -e environment.yml $(STACK_PARAMS) $(STACKNAME)
 
 deploy-infra: stack.yml environment.yml
 	@touch .deploy.$(STACKNAME)
-	openstack stack create -t $< -e environment.yml $(STACK_PARAMS) --parameter deploy_infrastructure=true $(STACKNAME)
+	openstack stack create --timeout 4800 -t $< -e environment.yml $(STACK_PARAMS) --parameter deploy_infrastructure=true $(STACKNAME)
 
 deploy-infra-ceph: stack.yml environment.yml
 	@touch .deploy.$(STACKNAME)
-	openstack stack create -t $< -e environment.yml $(STACK_PARAMS) --parameter deploy_infrastructure=true --parameter deploy_ceph=true $(STACKNAME)
+	openstack stack create --timeout 6600 -t $< -e environment.yml $(STACK_PARAMS) --parameter deploy_infrastructure=true --parameter deploy_ceph=true $(STACKNAME)
 
 deploy-infra-ceph-openstack: stack.yml environment.yml
 	@touch .deploy.$(STACKNAME)
-	openstack stack create -t $< -e environment.yml $(STACK_PARAMS) --parameter deploy_infrastructure=true --parameter deploy_ceph=true --parameter deploy_openstack=true $(STACKNAME)
+	openstack stack create --timeout 9000 -t $< -e environment.yml $(STACK_PARAMS) --parameter deploy_infrastructure=true --parameter deploy_ceph=true --parameter deploy_openstack=true $(STACKNAME)
 
 clean:
 	openstack stack delete -y $(STACKNAME)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ watch: .deploy.$(STACKNAME)
 			MGR_ADR=$$(openstack stack output show $(STACKNAME) manager_address -f value -c output_value); \
 			echo "MANAGER_ADDRESS=$$MGR_ADR" > .MANAGER_ADDRESS.$(STACKNAME); \
 		fi; \
-		if test -n "$$MGR_ADR"; then ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa.testbed ubuntu@$$MGR_ADR "sudo grep PLAY /var/log/cloud-init-output.log | grep -v 'PLAY \(\[\(Group hosts\|Gather facts\)\|RECAP\)' | tail -n3; sudo tail -n12 /var/log/cloud-init-output.log"; fi; \
+		if test -n "$$MGR_ADR"; then ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa.$(STACKNAME) ubuntu@$$MGR_ADR "sudo grep PLAY /var/log/cloud-init-output.log | grep -v 'PLAY \(\[\(Group hosts\|Gather facts\)\|RECAP\)' | tail -n3; sudo tail -n12 /var/log/cloud-init-output.log"; fi; \
 		STAT=$$(openstack stack list -f value -c "Stack Name" -c "Stack Status" | grep $(STACKNAME) | cut -d' ' -f2); \
 		if test "$$STAT" == "CREATE_COMPLETE"; then break; fi; \
 		if test "$$STAT" == "CREATE_FAILED"; then openstack stack show $(STACKNAME) -f value -c "stack_status_reason"; break; fi; \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ watch: .deploy.$(STACKNAME)
 			MGR_ADR=$$(openstack stack output show $(STACKNAME) manager_address -f value -c output_value); \
 			echo "MANAGER_ADDRESS=$$MGR_ADR" > .MANAGER_ADDRESS.$(STACKNAME); \
 		fi; \
-		if test -n "$$MGR_ADR"; then ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa.testbed ubuntu@$$MGR_ADR "sudo tail -n16 /var/log/cloud-init-output.log"; fi; \
+		if test -n "$$MGR_ADR"; then ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa.testbed ubuntu@$$MGR_ADR "sudo grep PLAY /var/log/cloud-init-output.log | grep -v 'PLAY \(\[\(Apply role\|Group hosts\|Gather facts\)\|RECAP\)' | tail -n3; sudo tail -n12 /var/log/cloud-init-output.log"; fi; \
 		STAT=$$(openstack stack list -f value -c "Stack Name" -c "Stack Status" | grep $(STACKNAME) | cut -d' ' -f2); \
 		if test "$$STAT" == "CREATE_COMPLETE"; then break; fi; \
 		if test "$$STAT" == "CREATE_FAILED"; then openstack stack show $(STACKNAME) -f value -c "stack_status_reason"; break; fi; \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ watch: .deploy.$(STACKNAME)
 			MGR_ADR=$$(openstack stack output show $(STACKNAME) manager_address -f value -c output_value); \
 			echo "MANAGER_ADDRESS=$$MGR_ADR" > .MANAGER_ADDRESS.$(STACKNAME); \
 		fi; \
-		if test -n "$$MGR_ADR"; then ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa.testbed ubuntu@$$MGR_ADR "sudo grep PLAY /var/log/cloud-init-output.log | grep -v 'PLAY \(\[\(Apply role\|Group hosts\|Gather facts\)\|RECAP\)' | tail -n3; sudo tail -n12 /var/log/cloud-init-output.log"; fi; \
+		if test -n "$$MGR_ADR"; then ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa.testbed ubuntu@$$MGR_ADR "sudo grep PLAY /var/log/cloud-init-output.log | grep -v 'PLAY \(\[\(Group hosts\|Gather facts\)\|RECAP\)' | tail -n3; sudo tail -n12 /var/log/cloud-init-output.log"; fi; \
 		STAT=$$(openstack stack list -f value -c "Stack Name" -c "Stack Status" | grep $(STACKNAME) | cut -d' ' -f2); \
 		if test "$$STAT" == "CREATE_COMPLETE"; then break; fi; \
 		if test "$$STAT" == "CREATE_FAILED"; then openstack stack show $(STACKNAME) -f value -c "stack_status_reason"; break; fi; \

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ watch: .deploy.$(STACKNAME)
 
 sshuttle: ~/.ssh/id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
 	source ./.MANAGER_ADDRESS.$(STACKNAME); \
-	sshuttle --ssh-command "ssh -i $<" -r dragon@$$MANAGER_ADDRESS 192.168.40.0/24 192.168.50.0/24 192.168.90.0/24
+	sshuttle --ssh-cmd "ssh -i $<" -r dragon@$$MANAGER_ADDRESS 192.168.40.0/24 192.168.50.0/24 192.168.90.0/24
 
 ssh_manager: ~/.ssh/id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
 	source ./.MANAGER_ADDRESS.$(STACKNAME); \

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,24 @@
 # Makefile
-# Common operations
-default: stack.yml stack-single.yml
+# Shortcuts to invoke OSISM testbed stack generation
+# Pass STACKNAME=XXX to change the name of the deployed stack (default: testbed),
+# STACK_PARAMS= (e.g. --parameter XYZ=abs) if you want to pass parameter to heat
+# TMPL_PARAMS= (e.g. -Dnumber_of_volumes=4) if you want to modify the stack
+#  generation from the template.
+# 
+# (c) Kurt Garloff <scs@garloff.de>, 3/2020, Apache2 License
 
 STACKNAME = testbed
 
+default: stack.yml stack-single.yml
+
 stack.yml: templates/stack.yml.j2
-	jinja2 -o $@ $^
+	jinja2 -o $@ $(TMPL_PARAMS) $^
 
 stack-single.yml: templates/stack.yml.j2
-	jinja2 -o $@ -Dnumber_of_nodes=0 $^
+	jinja2 -o $@ $(TMPL_PARAMS) -Dnumber_of_nodes=0 $^
+
+dry-run: stack.yml environment.yml
+	openstack stack create --dry-run -t $< -e environment.yml $(STACK_PARAMS) $(STACKNAME)
 
 deploy: stack.yml environment.yml
 	@touch .deploy.$(STACKNAME)
@@ -26,11 +36,26 @@ deploy-infra-ceph-openstack: stack.yml environment.yml
 	@touch .deploy.$(STACKNAME)
 	openstack stack create --timeout 9000 -t $< -e environment.yml $(STACK_PARAMS) --parameter deploy_infrastructure=true --parameter deploy_ceph=true --parameter deploy_openstack=true $(STACKNAME)
 
+update: stack.yml environment.yml
+	@touch .deploy.$(STACKNAME)
+	openstack stack update -t $< -e environment.yml $(STACK_PARAMS) $(STACKNAME)
+
+# Cleanup
 clean:
 	openstack stack delete -y $(STACKNAME)
 	@rm -f .deploy.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
 	rm -f ~/.ssh/id_rsa.$(STACKNAME)
 
+clean-wait:
+	openstack stack delete -y --wait $(STACKNAME)
+	@rm -f .deploy.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
+	rm -f ~/.ssh/id_rsa.$(STACKNAME)
+
+# To recover from stale ssh-key and MANAGER_ADDRESS
+reset:
+	@rm .deploy.$(STACKNAME)
+
+# Watch the creation of the stack
 watch: .deploy.$(STACKNAME)
 	MGR_ADR=""; STAT=""; while true; do\
 		date; openstack stack list; \
@@ -49,11 +74,12 @@ watch: .deploy.$(STACKNAME)
 		echo; sleep 30; \
 	done
 
-
+# Look for stack
 .deploy.$(STACKNAME):
 	STAT=$$(openstack stack list -f value -c "Stack Name" -c "Stack Status" | grep $(STACKNAME) | cut -d' ' -f2); \
 	if test -n "$$STAT"; then touch .deploy.$(STACKNAME); else echo "use make deploy or deploy-infra or ...."; exit 1; fi
 
+# Get output
 ~/.ssh/id_rsa.$(STACKNAME): .deploy.$(STACKNAME)
 	openstack stack output show $(STACKNAME) private_key -f value -c output_value > $@
 	chmod 0600 $@
@@ -63,6 +89,7 @@ watch: .deploy.$(STACKNAME)
 	echo "MANAGER_ADDRESS=$$MANAGER_ADDRESS" > $@; \
 	echo $$MANAGER_ADDRESS
 
+# Convenience: sshuttle invocation
 sshuttle: ~/.ssh/id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
 	source ./.MANAGER_ADDRESS.$(STACKNAME); \
 	sshuttle --ssh-cmd "ssh -i $<" -r dragon@$$MANAGER_ADDRESS 192.168.40.0/24 192.168.50.0/24 192.168.90.0/24
@@ -71,4 +98,5 @@ ssh_manager: ~/.ssh/id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
 	source ./.MANAGER_ADDRESS.$(STACKNAME); \
 	ssh -i $< dragon@$$MANAGER_ADDRESS
 
-.PHONY: clean watch sshuttle ssh_manager deploy deploy-infra deploy-infra-ceph deploy-infra-ceph-openstack
+# avoid confusing make by non-file targets
+.PHONY: clean clean-wait reset watch sshuttle ssh_manager dry-run deploy deploy-infra deploy-infra-ceph deploy-infra-ceph-openstack

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ watch: .deploy.$(STACKNAME)
 sshuttle: ~/.ssh/id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
 	eval $$(ssh-agent); ssh-add $<; \
 	source ./.MANAGER_ADDRESS.$(STACKNAME); \
-	sshuttle dragon@$$MANAGER_ADDRESS 192.168.40.0/24 192.168.50.0/24 192.168.90.0/24
+	sshuttle -r dragon@$$MANAGER_ADDRESS 192.168.40.0/24 192.168.50.0/24 192.168.90.0/24
 
 ssh_manager: ~/.ssh/id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
 	source ./.MANAGER_ADDRESS.$(STACKNAME); \

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ watch: .deploy.$(STACKNAME)
 		SRV=$$(openstack server list -f value -c "Name" -c "Status" | grep testbed-manager | cut -d ' ' -f2); \
 		openstack server list; \
 		if test -z "$$MGR_ADR" -a "$$SRV" = "ACTIVE"; then \
-			openstack stack output show $(STACKNAME) private_key -f value -c output_value > ~/.ssh/id_rsa.testbed; \
-			chmod 0600 ~/.ssh/id_rsa.testbed; \
+			openstack stack output show $(STACKNAME) private_key -f value -c output_value > ~/.ssh/id_rsa.$(STACKNAME); \
+			chmod 0600 ~/.ssh/id_rsa.$(STACKNAME); \
 			MGR_ADR=$$(openstack stack output show $(STACKNAME) manager_address -f value -c output_value); \
 			echo "MANAGER_ADDRESS=$$MGR_ADR" > .MANAGER_ADDRESS.$(STACKNAME); \
 		fi; \
@@ -64,9 +64,8 @@ watch: .deploy.$(STACKNAME)
 	echo $$MANAGER_ADDRESS
 
 sshuttle: ~/.ssh/id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
-	eval $$(ssh-agent); ssh-add $<; \
 	source ./.MANAGER_ADDRESS.$(STACKNAME); \
-	sshuttle -r dragon@$$MANAGER_ADDRESS 192.168.40.0/24 192.168.50.0/24 192.168.90.0/24
+	sshuttle --ssh-command "ssh -i $<" -r dragon@$$MANAGER_ADDRESS 192.168.40.0/24 192.168.50.0/24 192.168.90.0/24
 
 ssh_manager: ~/.ssh/id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
 	source ./.MANAGER_ADDRESS.$(STACKNAME); \

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ openstack --os-cloud testbed \
 This can also be achieved using ``make deploy``.
 
 Docker etc. are already installed during stack creation. Therefore the creation takes some time.
+You can use ``make watch`` to watch the installation proceeding.
 
 The manager is started after the deployment of the HCI nodes has been completed. This is necessary to
 be able to carry out various preparatory steps after the manager has been made available.

--- a/README.md
+++ b/README.md
@@ -430,8 +430,12 @@ openstack --os-cloud testbed \
   --parameter deploy_ceph=true \
   --parameter deploy_infrastructure=true \
   --parameter deploy_openstack=true \
+  --timeout 9000 \
   -t stack.yml testbed
 ```
+
+The ``--timeout 9000`` parameter avoids heat giving up too early.
+(The default timeout for heat stacks is typically 3600.)
 
 This can also be achieved using ``make deploy-infra-ceph-openstack``.
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,8 @@
 parameter_defaults:
   availability_zone: south-1
   volume_az: south-1
-  flavor_controller: 4C-16GB-40GB
-  flavor_node: 2C-4GB-20GB
+  flavor_node: 4C-16GB-40GB
+  flavor_manager: 2C-4GB-20GB
   image: Ubuntu 18.04
   public: public
   volume_size_storage: 10

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@
 parameter_defaults:
   availability_zone: south-1
   flavor_controller: 4C-16GB-40GB
-  flavor_manager: 2C-4GB-20GB
+  flavor_node: 2C-4GB-20GB
   image: Ubuntu 18.04
   public: public
   volume_size_storage: 10

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 ---
 parameter_defaults:
   availability_zone: south-1
+  volume_az: south-1
   flavor_controller: 4C-16GB-40GB
   flavor_node: 2C-4GB-20GB
   image: Ubuntu 18.04

--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,5 @@ parameter_defaults:
   image: Ubuntu 18.04
   public: public
   volume_size_storage: 10
+  ceph_version: luminous
+  openstack_version: rocky

--- a/stack-single.yml
+++ b/stack-single.yml
@@ -42,6 +42,10 @@ parameters:
     type: boolean
     default: false
 
+  drives_vdx:
+    type: boolean
+    default: false
+
 ##########
 resources:
 
@@ -86,6 +90,7 @@ resources:
                   deploy_ceph: {get_param: deploy_ceph}
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
+                  drives_vdx: {get_param: drives_vdx}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -149,6 +154,11 @@ resources:
                       # deploy helper services
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-infrastructure helper --tags sshconfig'
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-run custom generate-ssh-known-hosts'
+
+                      # Fixup drive names sdX -> vdX IF drives_vdx is set (TODO: Could autodetect this)
+                      if [[ "drives_vdx" == "True" ]]; then
+                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" $file; done'
+                      fi
                   fi
 
                   if [[ "deploy_infrastructure" == "True" ]]; then

--- a/stack-single.yml
+++ b/stack-single.yml
@@ -46,6 +46,16 @@ parameters:
     type: boolean
     default: false
 
+# select luminous or nautilus
+  ceph_version:
+    type: string
+    default: luminous
+
+# select rocky, stein, train
+  openstack_version:
+    type: string
+    default: rocky
+
 ##########
 resources:
 
@@ -91,6 +101,8 @@ resources:
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
                   drives_vdx: {get_param: drives_vdx}
+                  ceph_version: {get_param: ceph_version}
+                  openstack_version: {get_param: openstack_version}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -121,6 +133,8 @@ resources:
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-1.yml | sudo -iu dragon tee /home/dragon/manager-part-1.yml
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-2.yml | sudo -iu dragon tee /home/dragon/manager-part-2.yml
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-1.yml
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-ceph-version.sh ceph_version'
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-openstack-version.sh openstack_version'
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-2.yml
 
                   sudo -iu dragon docker cp /home/dragon/.ssh/id_rsa.pub manager_osism-ansible_1:/share/id_rsa.pub

--- a/stack-single.yml
+++ b/stack-single.yml
@@ -157,7 +157,7 @@ resources:
 
                       # Fixup drive names sdX -> vdX IF drives_vdx is set (TODO: Could autodetect this)
                       if [[ "drives_vdx" == "True" ]]; then
-                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" $file; done'
+                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" ${file}; done'
                       fi
                   fi
 

--- a/stack-single.yml
+++ b/stack-single.yml
@@ -20,6 +20,10 @@ parameters:
     type: string
     default: south-1
 
+  volume_az:
+    type: string
+    default: south-1
+
   public:
     type: string
     constraints:

--- a/stack.yml
+++ b/stack.yml
@@ -52,6 +52,10 @@ parameters:
     type: boolean
     default: false
 
+  drives_vdx:
+    type: boolean
+    default: false
+
 ##########
 resources:
 
@@ -107,6 +111,7 @@ resources:
                   deploy_ceph: {get_param: deploy_ceph}
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
+                  drives_vdx: {get_param: drives_vdx}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -170,6 +175,11 @@ resources:
                       # deploy helper services
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-infrastructure helper --tags sshconfig'
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-run custom generate-ssh-known-hosts'
+
+                      # Fixup drive names sdX -> vdX IF drives_vdx is set (TODO: Could autodetect this)
+                      if [[ "drives_vdx" == "True" ]]; then
+                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" $file; done'
+                      fi
                   fi
 
                   if [[ "deploy_infrastructure" == "True" ]]; then

--- a/stack.yml
+++ b/stack.yml
@@ -56,6 +56,16 @@ parameters:
     type: boolean
     default: false
 
+# select luminous or nautilus
+  ceph_version:
+    type: string
+    default: luminous
+
+# select rocky, stein, train
+  openstack_version:
+    type: string
+    default: rocky
+
 ##########
 resources:
 
@@ -112,6 +122,8 @@ resources:
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
                   drives_vdx: {get_param: drives_vdx}
+                  ceph_version: {get_param: ceph_version}
+                  openstack_version: {get_param: openstack_version}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -142,6 +154,8 @@ resources:
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-1.yml | sudo -iu dragon tee /home/dragon/manager-part-1.yml
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-2.yml | sudo -iu dragon tee /home/dragon/manager-part-2.yml
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-1.yml
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-ceph-version.sh ceph_version'
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-openstack-version.sh openstack_version'
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-2.yml
 
                   sudo -iu dragon docker cp /home/dragon/.ssh/id_rsa.pub manager_osism-ansible_1:/share/id_rsa.pub

--- a/stack.yml
+++ b/stack.yml
@@ -30,6 +30,10 @@ parameters:
     type: string
     default: south-1
 
+  volume_az:
+    type: string
+    default: south-1
+
   public:
     type: string
     constraints:
@@ -602,6 +606,7 @@ resources:
     properties:
       name: testbed-node-0-volume-0
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_0_volume_0_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -614,6 +619,7 @@ resources:
     properties:
       name: testbed-node-0-volume-1
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_0_volume_1_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -626,6 +632,7 @@ resources:
     properties:
       name: testbed-node-0-volume-2
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_0_volume_2_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -718,6 +725,7 @@ resources:
     properties:
       name: testbed-node-1-volume-0
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_1_volume_0_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -730,6 +738,7 @@ resources:
     properties:
       name: testbed-node-1-volume-1
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_1_volume_1_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -742,6 +751,7 @@ resources:
     properties:
       name: testbed-node-1-volume-2
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_1_volume_2_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -834,6 +844,7 @@ resources:
     properties:
       name: testbed-node-2-volume-0
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_2_volume_0_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -846,6 +857,7 @@ resources:
     properties:
       name: testbed-node-2-volume-1
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_2_volume_1_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -858,6 +870,7 @@ resources:
     properties:
       name: testbed-node-2-volume-2
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_2_volume_2_attachment:
     type: OS::Cinder::VolumeAttachment

--- a/stack.yml
+++ b/stack.yml
@@ -178,7 +178,7 @@ resources:
 
                       # Fixup drive names sdX -> vdX IF drives_vdx is set (TODO: Could autodetect this)
                       if [[ "drives_vdx" == "True" ]]; then
-                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" $file; done'
+                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" ${file}; done'
                       fi
                   fi
 

--- a/templates/stack.yml.j2
+++ b/templates/stack.yml.j2
@@ -181,7 +181,7 @@ resources:
 
                       # Fixup drive names sdX -> vdX IF drives_vdx is set (TODO: Could autodetect this)
                       if [[ "drives_vdx" == "True" ]]; then
-                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" $file; done'
+                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" ${file}; done'
                       fi
                   fi
 

--- a/templates/stack.yml.j2
+++ b/templates/stack.yml.j2
@@ -57,6 +57,16 @@ parameters:
     type: boolean
     default: false
 
+# select luminous or nautilus
+  ceph_version:
+    type: string
+    default: luminous
+
+# select rocky, stein, train
+  openstack_version:
+    type: string
+    default: rocky
+
 ##########
 resources:
 
@@ -115,6 +125,8 @@ resources:
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
                   drives_vdx: {get_param: drives_vdx}
+                  ceph_version: {get_param: ceph_version}
+                  openstack_version: {get_param: openstack_version}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -145,6 +157,8 @@ resources:
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-1.yml | sudo -iu dragon tee /home/dragon/manager-part-1.yml
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-2.yml | sudo -iu dragon tee /home/dragon/manager-part-2.yml
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-1.yml
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-ceph-version.sh ceph_version'
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-openstack-version.sh openstack_version'
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-2.yml
 
                   sudo -iu dragon docker cp /home/dragon/.ssh/id_rsa.pub manager_osism-ansible_1:/share/id_rsa.pub

--- a/templates/stack.yml.j2
+++ b/templates/stack.yml.j2
@@ -31,6 +31,10 @@ parameters:
     type: string
     default: south-1
 
+  volume_az:
+    type: string
+    default: south-1
+
   public:
     type: string
     constraints:
@@ -608,6 +612,7 @@ resources:
     properties:
       name: testbed-node-{{ n }}-volume-{{ m }}
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_{{ n }}_volume_{{ m }}_attachment:
     type: OS::Cinder::VolumeAttachment

--- a/templates/stack.yml.j2
+++ b/templates/stack.yml.j2
@@ -53,6 +53,10 @@ parameters:
     type: boolean
     default: false
 
+  drives_vdx:
+    type: boolean
+    default: false
+
 ##########
 resources:
 
@@ -110,6 +114,7 @@ resources:
                   deploy_ceph: {get_param: deploy_ceph}
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
+                  drives_vdx: {get_param: drives_vdx}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -173,6 +178,11 @@ resources:
                       # deploy helper services
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-infrastructure helper --tags sshconfig'
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-run custom generate-ssh-known-hosts'
+
+                      # Fixup drive names sdX -> vdX IF drives_vdx is set (TODO: Could autodetect this)
+                      if [[ "drives_vdx" == "True" ]]; then
+                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" $file; done'
+                      fi
                   fi
 
                   if [[ "deploy_infrastructure" == "True" ]]; then


### PR DESCRIPTION
A bunch of fixes and useful additions for OSISM/testbed:

FIXES:
* The environment.yml had a flavor_controller that should have been spelled flavor_node.
* Volumes have an availability zone too. (Some clouds have one per compute AZ, typically requiring it to match, some have just a global one, despite several compute AZs.)
* Support drives_vdx parameter to change drive names. (This could be improved to autodetect things in a second step, might do so later.)

ADDITIONS:
* Makefile. It helps me to not get annoyed by typing (or c'n'p ing) the same longish commands again and again ...