### PR TITLE
Testbed flavor name

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The defaults for the stack parameters are intended for the Betacloud.
     <td><code>south-1</code></td>
   </tr>
   <tr>
-    <td><code>flavor_controller</code></td>
+    <td><code>flavor_node</code></td>
     <td><code>4C-16GB-40GB</code></td>
   </tr>
   <tr>
@@ -286,7 +286,7 @@ Further details on environments on https://docs.openstack.org/heat/latest/templa
 ---
 parameters:
   availability_zone: south-1
-  flavor_controller: 4C-16GB-40GB
+  flavor_node: 4C-16GB-40GB
   flavor_manager: 2C-4GB-20GB
   image: Ubuntu 18.04
   public: public

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 ---
 parameter_defaults:
   availability_zone: south-1
-  flavor_controller: 4C-16GB-40GB
+  flavor_node: 4C-16GB-40GB
   flavor_manager: 2C-4GB-20GB
   image: Ubuntu 18.04
   public: public


### PR DESCRIPTION
OK, this is a straight bugfix.
You misnamed the flavor_node as flavor_controller in environment.yml and the documentation.
Fixed with these patches.