### PR TITLE
Specify version

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@ The defaults for the stack parameters are intended for the Betacloud.
     <td><code>volume_size_storage</code></td>
     <td><code>10</code></td>
   </tr>
+  <tr>
+    <td><code>ceph_version</code></td>
+    <td><code>luminous</code></td>
+  </tr>
+  <tr>
+    <td><code>openstack_version</code></td>
+    <td><code>rocky</code></td>
+  </tr>
 </table>
 
 With the file ``environment.yml`` the parameters of the stack can be adjusted.
@@ -291,6 +299,8 @@ parameters:
   image: Ubuntu 18.04
   public: public
   volume_size_storage: 10
+  ceph_version: luminous
+  openstack_version: rocky
 ```
 
 ## Initialization
@@ -403,6 +413,11 @@ openstack --os-cloud testbed \
   -t stack.yml testbed
 ```
 
+The parameters ``ceph_version`` and ``openstack_version`` change the deployed versions of
+Ceph and OpenStack respectively from their defaults ``luminous`` and ``rocky``.
+For Ceph, ``nautilus`` can be used, for OpenStack, we can also test ``stein`` and ``train``.
+It should be noted that the defaults are tested best.
+
 ## Usage
 
 * Get private SSH key
@@ -469,6 +484,9 @@ openstack --os-cloud testbed \
 * Run ``./scripts/set-ceph-version.sh nautilus`` to set the Ceph version to ``nautilus``
 * Go to ``/home/dragon`` on the manager node
 * Run ``ansible-playbook manager-part-2.yml`` to update the manager
+
+This can also be achieved automatically by passing the wanted versions inside the environment
+``ceph_version`` and ``openstack_version`` respectively.
 
 ## Deploy
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,5 @@ parameter_defaults:
   image: Ubuntu 18.04
   public: public
   volume_size_storage: 10
+  ceph_version: luminous
+  openstack_version: rocky

--- a/stack-single.yml
+++ b/stack-single.yml
@@ -38,6 +38,16 @@ parameters:
     type: boolean
     default: false
 
+# select luminous or nautilus
+  ceph_version:
+    type: string
+    default: luminous
+
+# select rocky, stein, train
+  openstack_version:
+    type: string
+    default: rocky
+
 ##########
 resources:
 
@@ -82,6 +92,8 @@ resources:
                   deploy_ceph: {get_param: deploy_ceph}
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
+                  ceph_version: {get_param: ceph_version}
+                  openstack_version: {get_param: openstack_version}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -112,6 +124,8 @@ resources:
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-1.yml | sudo -iu dragon tee /home/dragon/manager-part-1.yml
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-2.yml | sudo -iu dragon tee /home/dragon/manager-part-2.yml
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-1.yml
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-ceph-version.sh ceph_version'
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-openstack-version.sh openstack_version'
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-2.yml
 
                   sudo -iu dragon docker cp /home/dragon/.ssh/id_rsa.pub manager_osism-ansible_1:/share/id_rsa.pub

--- a/stack.yml
+++ b/stack.yml
@@ -48,6 +48,16 @@ parameters:
     type: boolean
     default: false
 
+# select luminous or nautilus
+  ceph_version:
+    type: string
+    default: luminous
+
+# select rocky, stein, train
+  openstack_version:
+    type: string
+    default: rocky
+
 ##########
 resources:
 
@@ -103,6 +113,8 @@ resources:
                   deploy_ceph: {get_param: deploy_ceph}
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
+                  ceph_version: {get_param: ceph_version}
+                  openstack_version: {get_param: openstack_version}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -133,6 +145,8 @@ resources:
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-1.yml | sudo -iu dragon tee /home/dragon/manager-part-1.yml
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-2.yml | sudo -iu dragon tee /home/dragon/manager-part-2.yml
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-1.yml
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-ceph-version.sh ceph_version'
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-openstack-version.sh openstack_version'
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-2.yml
 
                   sudo -iu dragon docker cp /home/dragon/.ssh/id_rsa.pub manager_osism-ansible_1:/share/id_rsa.pub

--- a/templates/stack.yml.j2
+++ b/templates/stack.yml.j2
@@ -49,6 +49,16 @@ parameters:
     type: boolean
     default: false
 
+# select luminous or nautilus
+  ceph_version:
+    type: string
+    default: luminous
+
+# select rocky, stein, train
+  openstack_version:
+    type: string
+    default: rocky
+
 ##########
 resources:
 
@@ -106,6 +116,8 @@ resources:
                   deploy_ceph: {get_param: deploy_ceph}
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
+                  ceph_version: {get_param: ceph_version}
+                  openstack_version: {get_param: openstack_version}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -136,6 +148,8 @@ resources:
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-1.yml | sudo -iu dragon tee /home/dragon/manager-part-1.yml
                   curl https://raw.githubusercontent.com/osism/testbed/master/playbooks/manager-part-2.yml | sudo -iu dragon tee /home/dragon/manager-part-2.yml
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-1.yml
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-ceph-version.sh ceph_version'
+                  sudo -iu dragon sh -c 'cd /opt/configuration; ./scripts/set-openstack-version.sh openstack_version'
                   sudo -iu dragon ansible-playbook -i localhost, /home/dragon/manager-part-2.yml
 
                   sudo -iu dragon docker cp /home/dragon/.ssh/id_rsa.pub manager_osism-ansible_1:/share/id_rsa.pub


### PR DESCRIPTION
This allows to specify ceph_version and openstack_version as parameters to heat, so a fully automated deployment of various versions can be done without manual intervention.
