### PR TITLE
Volume az

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The defaults for the stack parameters are intended for the Betacloud.
     <td><code>south-1</code></td>
   </tr>
   <tr>
-    <td><code>volume_az</code></td>
+    <td><code>volume_availability_zone</code></td>
     <td><code>south-1</code></td>
   </tr>
   <tr>
@@ -290,7 +290,7 @@ Further details on environments on https://docs.openstack.org/heat/latest/templa
 ---
 parameters:
   availability_zone: south-1
-  volume_az: south-1
+  volume_availability_zone: south-1
   flavor_node: 4C-16GB-40GB
   flavor_manager: 2C-4GB-20GB
   image: Ubuntu 18.04

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ The defaults for the stack parameters are intended for the Betacloud.
     <td><code>south-1</code></td>
   </tr>
   <tr>
+    <td><code>volume_az</code></td>
+    <td><code>south-1</code></td>
+  </tr>
+  <tr>
     <td><code>flavor_node</code></td>
     <td><code>4C-16GB-40GB</code></td>
   </tr>
@@ -286,6 +290,7 @@ Further details on environments on https://docs.openstack.org/heat/latest/templa
 ---
 parameters:
   availability_zone: south-1
+  volume_az: south-1
   flavor_node: 4C-16GB-40GB
   flavor_manager: 2C-4GB-20GB
   image: Ubuntu 18.04

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 ---
 parameter_defaults:
   availability_zone: south-1
+  volume_az: south-1
   flavor_node: 4C-16GB-40GB
   flavor_manager: 2C-4GB-20GB
   image: Ubuntu 18.04

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 ---
 parameter_defaults:
   availability_zone: south-1
-  volume_az: south-1
+  volume_availability_zone: south-1
   flavor_node: 4C-16GB-40GB
   flavor_manager: 2C-4GB-20GB
   image: Ubuntu 18.04

--- a/stack-single.yml
+++ b/stack-single.yml
@@ -20,7 +20,7 @@ parameters:
     type: string
     default: south-1
 
-  volume_az:
+  volume_availability_zone:
     type: string
     default: south-1
 

--- a/stack-single.yml
+++ b/stack-single.yml
@@ -20,6 +20,10 @@ parameters:
     type: string
     default: south-1
 
+  volume_az:
+    type: string
+    default: south-1
+
   public:
     type: string
     constraints:

--- a/stack.yml
+++ b/stack.yml
@@ -30,7 +30,7 @@ parameters:
     type: string
     default: south-1
 
-  volume_az:
+  volume_availability_zone:
     type: string
     default: south-1
 
@@ -606,7 +606,7 @@ resources:
     properties:
       name: testbed-node-0-volume-0
       size: {get_param: volume_size_storage}
-      availability_zone: {get_param: volume_az}
+      availability_zone: {get_param: volume_availability_zone}
 
   node_0_volume_0_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -619,7 +619,7 @@ resources:
     properties:
       name: testbed-node-0-volume-1
       size: {get_param: volume_size_storage}
-      availability_zone: {get_param: volume_az}
+      availability_zone: {get_param: volume_availability_zone}
 
   node_0_volume_1_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -632,7 +632,7 @@ resources:
     properties:
       name: testbed-node-0-volume-2
       size: {get_param: volume_size_storage}
-      availability_zone: {get_param: volume_az}
+      availability_zone: {get_param: volume_availability_zone}
 
   node_0_volume_2_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -725,7 +725,7 @@ resources:
     properties:
       name: testbed-node-1-volume-0
       size: {get_param: volume_size_storage}
-      availability_zone: {get_param: volume_az}
+      availability_zone: {get_param: volume_availability_zone}
 
   node_1_volume_0_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -738,7 +738,7 @@ resources:
     properties:
       name: testbed-node-1-volume-1
       size: {get_param: volume_size_storage}
-      availability_zone: {get_param: volume_az}
+      availability_zone: {get_param: volume_availability_zone}
 
   node_1_volume_1_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -751,7 +751,7 @@ resources:
     properties:
       name: testbed-node-1-volume-2
       size: {get_param: volume_size_storage}
-      availability_zone: {get_param: volume_az}
+      availability_zone: {get_param: volume_availability_zone}
 
   node_1_volume_2_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -844,7 +844,7 @@ resources:
     properties:
       name: testbed-node-2-volume-0
       size: {get_param: volume_size_storage}
-      availability_zone: {get_param: volume_az}
+      availability_zone: {get_param: volume_availability_zone}
 
   node_2_volume_0_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -857,7 +857,7 @@ resources:
     properties:
       name: testbed-node-2-volume-1
       size: {get_param: volume_size_storage}
-      availability_zone: {get_param: volume_az}
+      availability_zone: {get_param: volume_availability_zone}
 
   node_2_volume_1_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -870,7 +870,7 @@ resources:
     properties:
       name: testbed-node-2-volume-2
       size: {get_param: volume_size_storage}
-      availability_zone: {get_param: volume_az}
+      availability_zone: {get_param: volume_availability_zone}
 
   node_2_volume_2_attachment:
     type: OS::Cinder::VolumeAttachment

--- a/stack.yml
+++ b/stack.yml
@@ -30,6 +30,10 @@ parameters:
     type: string
     default: south-1
 
+  volume_az:
+    type: string
+    default: south-1
+
   public:
     type: string
     constraints:
@@ -602,6 +606,7 @@ resources:
     properties:
       name: testbed-node-0-volume-0
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_0_volume_0_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -614,6 +619,7 @@ resources:
     properties:
       name: testbed-node-0-volume-1
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_0_volume_1_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -626,6 +632,7 @@ resources:
     properties:
       name: testbed-node-0-volume-2
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_0_volume_2_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -718,6 +725,7 @@ resources:
     properties:
       name: testbed-node-1-volume-0
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_1_volume_0_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -730,6 +738,7 @@ resources:
     properties:
       name: testbed-node-1-volume-1
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_1_volume_1_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -742,6 +751,7 @@ resources:
     properties:
       name: testbed-node-1-volume-2
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_1_volume_2_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -834,6 +844,7 @@ resources:
     properties:
       name: testbed-node-2-volume-0
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_2_volume_0_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -846,6 +857,7 @@ resources:
     properties:
       name: testbed-node-2-volume-1
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_2_volume_1_attachment:
     type: OS::Cinder::VolumeAttachment
@@ -858,6 +870,7 @@ resources:
     properties:
       name: testbed-node-2-volume-2
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_2_volume_2_attachment:
     type: OS::Cinder::VolumeAttachment

--- a/templates/stack.yml.j2
+++ b/templates/stack.yml.j2
@@ -31,7 +31,7 @@ parameters:
     type: string
     default: south-1
 
-  volume_az:
+  volume_availability_zone:
     type: string
     default: south-1
 
@@ -612,7 +612,7 @@ resources:
     properties:
       name: testbed-node-{{ n }}-volume-{{ m }}
       size: {get_param: volume_size_storage}
-      availability_zone: {get_param: volume_az}
+      availability_zone: {get_param: volume_availability_zone}
 
   node_{{ n }}_volume_{{ m }}_attachment:
     type: OS::Cinder::VolumeAttachment

--- a/templates/stack.yml.j2
+++ b/templates/stack.yml.j2
@@ -31,6 +31,10 @@ parameters:
     type: string
     default: south-1
 
+  volume_az:
+    type: string
+    default: south-1
+
   public:
     type: string
     constraints:
@@ -608,6 +612,7 @@ resources:
     properties:
       name: testbed-node-{{ n }}-volume-{{ m }}
       size: {get_param: volume_size_storage}
+      availability_zone: {get_param: volume_az}
 
   node_{{ n }}_volume_{{ m }}_attachment:
     type: OS::Cinder::VolumeAttachment


### PR DESCRIPTION
Specify availability_zone for volumes.

In some clouds, there is more than one AZ for volumes, so it makes
sense to specify it. It typically should match the AZ for the VMs,
but let's keep it separate for flexibility. (Some clouds may have
several AZs for VMs, but only one replicated solution across AZs.)
In OTC, you need to match volume_az with availabilty_zone, otherwise
attachment fails. Leaving it open leaves it to chance ...