### PR TITLE
Drives vdx

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The following stable releases are supported. The development branch usually work
 ## Test status of cloud providers
 
 * [Betacloud](https://www.betacloud.de): Works
-* [Citycloud](https://www.citycloud.com): Works (need to change disk names from sdX to vdX before deploying Ceph on manager node ``/opt/configuration/inventory/host_vars/testbed-node-?.osism.local.yml``)
-* [OTC](https://open-telekom-cloud.com/): Needs ``enable_snat``, ``enable_dhcp`` and older heat, still fails
-* [teuto.stack](https://teutostack.de/): Currently lacks support for heat
+* [Citycloud](https://www.citycloud.com): Works (need to change disk names from sdX to vdX, pass ``drives_vdx: true`` in environment)
+* [OTC](https://open-telekom-cloud.com/): Needs ``enable_snat``, ``enable_dhcp``, ``dns_nameservers``, fixup NIC names via custom runcmd commands and an older heatversion. It also needs two cloud-init patches to get get userdata.
+* [teuto.stack](https://teutostack.de/): Currently lacks support for heat.
 
 ## Requirements
 
@@ -277,6 +277,10 @@ The defaults for the stack parameters are intended for the Betacloud.
     <td><code>volume_size_storage</code></td>
     <td><code>10</code></td>
   </tr>
+  <tr>
+    <td><code>drives_vdx</code></td>
+    <td><code>false</code></td>
+  </tr>
 </table>
 
 With the file ``environment.yml`` the parameters of the stack can be adjusted.
@@ -291,6 +295,7 @@ parameters:
   image: Ubuntu 18.04
   public: public
   volume_size_storage: 10
+  drives_vdx: false
 ```
 
 ## Initialization
@@ -402,6 +407,10 @@ openstack --os-cloud testbed \
   --parameter deploy_openstack=true \
   -t stack.yml testbed
 ```
+
+The parameter ``--parameter drives_vdx=true`` can be passed (or ``drives_vdx: true`` be set
+in ``environment.yml``) to change the testbed to use virtio disk names (``vdx``) rather than
+SCSI disk names (``sdx``).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The defaults for the stack parameters are intended for the Betacloud.
     <td><code>south-1</code></td>
   </tr>
   <tr>
-    <td><code>flavor_controller</code></td>
+    <td><code>flavor_node</code></td>
     <td><code>4C-16GB-40GB</code></td>
   </tr>
   <tr>
@@ -286,7 +286,7 @@ Further details on environments on https://docs.openstack.org/heat/latest/templa
 ---
 parameters:
   availability_zone: south-1
-  flavor_controller: 4C-16GB-40GB
+  flavor_node: 4C-16GB-40GB
   flavor_manager: 2C-4GB-20GB
   image: Ubuntu 18.04
   public: public

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ parameter_defaults:
   image: Ubuntu 18.04
   public: public
   volume_size_storage: 10
+  drives_vdx: false

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 ---
 parameter_defaults:
   availability_zone: south-1
-  flavor_controller: 4C-16GB-40GB
+  flavor_node: 4C-16GB-40GB
   flavor_manager: 2C-4GB-20GB
   image: Ubuntu 18.04
   public: public

--- a/stack-single.yml
+++ b/stack-single.yml
@@ -38,6 +38,10 @@ parameters:
     type: boolean
     default: false
 
+  drives_vdx:
+    type: boolean
+    default: false
+
 ##########
 resources:
 
@@ -82,6 +86,7 @@ resources:
                   deploy_ceph: {get_param: deploy_ceph}
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
+                  drives_vdx: {get_param: drives_vdx}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -145,6 +150,11 @@ resources:
                       # deploy helper services
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-infrastructure helper --tags sshconfig'
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-run custom generate-ssh-known-hosts'
+
+                      # Fixup drive names sdX -> vdX IF drives_vdx is set (TODO: Could autodetect this)
+                      if [[ "drives_vdx" == "True" ]]; then
+                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" ${file}; done'
+                      fi
                   fi
 
                   if [[ "deploy_infrastructure" == "True" ]]; then

--- a/stack.yml
+++ b/stack.yml
@@ -48,6 +48,10 @@ parameters:
     type: boolean
     default: false
 
+  drives_vdx:
+    type: boolean
+    default: false
+
 ##########
 resources:
 
@@ -103,6 +107,7 @@ resources:
                   deploy_ceph: {get_param: deploy_ceph}
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
+                  drives_vdx: {get_param: drives_vdx}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -166,6 +171,11 @@ resources:
                       # deploy helper services
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-infrastructure helper --tags sshconfig'
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-run custom generate-ssh-known-hosts'
+
+                      # Fixup drive names sdX -> vdX IF drives_vdx is set (TODO: Could autodetect this)
+                      if [[ "drives_vdx" == "True" ]]; then
+                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" ${file}; done'
+                      fi
                   fi
 
                   if [[ "deploy_infrastructure" == "True" ]]; then

--- a/templates/stack.yml.j2
+++ b/templates/stack.yml.j2
@@ -49,6 +49,10 @@ parameters:
     type: boolean
     default: false
 
+  drives_vdx:
+    type: boolean
+    default: false
+
 ##########
 resources:
 
@@ -106,6 +110,7 @@ resources:
                   deploy_ceph: {get_param: deploy_ceph}
                   deploy_infrastructure: {get_param: deploy_infrastructure}
                   deploy_openstack: {get_param: deploy_openstack}
+                  drives_vdx: {get_param: drives_vdx}
                   wc_notify: {get_attr: ['manager_wait_handle', 'curl_cli']}
                 template: |
                   #!/usr/bin/env bash
@@ -169,6 +174,11 @@ resources:
                       # deploy helper services
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-infrastructure helper --tags sshconfig'
                       sudo -iu dragon sh -c 'INTERACTIVE=false osism-run custom generate-ssh-known-hosts'
+
+                      # Fixup drive names sdX -> vdX IF drives_vdx is set (TODO: Could autodetect this)
+                      if [[ "drives_vdx" == "True" ]]; then
+                        sudo -iu dragon sh -c 'for file in /opt/configuration/inventory/host_vars/testbed*.yml; do sed -i "s@/dev/sd\([a-z]\)@/dev/vd\1@g" ${file}; done'
+                      fi
                   fi
 
                   if [[ "deploy_infrastructure" == "True" ]]; then


### PR DESCRIPTION
This allows to pass a parameter drives_vdx: true, which causes the automation to replace sdX with vdX in the host_vars inventory.
Note that I consider this an intermediate solution.

For the final solution, we need to discuss how to handle defaults/auto-detection/specification of disk names and NIC names.
(Note that NIC names are the more tricky piece!)

Options:
1. Try to autodetect everything. This should work reasonably well for disks, but there's no 100% safe way to detect the order of the network interfaces correctly. (We can probably guess 95% correctly though ... but specific clouds may actually have special high-perf NICs that we can't use then.)
2. Allow user to specify the disk and NIC names in the environment.yml.
3. Combine both by defaulting to an auto-detection allowing to override via environment.yml

For now, drives_vdx: true allows to use a number of clouds without additional manual intervention, so it still seems to be a useful intermediate step.