### PR TITLE
ansible: enable deprecation warnings

### DIFF
--- a/environments/ansible.cfg
+++ b/environments/ansible.cfg
@@ -1,7 +1,4 @@
 [defaults]
-# hide deprecation warnings
-deprecation_warnings = false
-
 # hide "[WARNING]: Invalid characters were found in group names but not replaced,
 # use -vvvv to see details" warning message
 force_valid_group_names = ignore


### PR DESCRIPTION
It is useful to see deprecation warnings on the testbed.