### PR TITLE
Fix cloudkitty

### DIFF
--- a/environments/kolla/files/overlays/cloudkitty.conf
+++ b/environments/kolla/files/overlays/cloudkitty.conf
@@ -1,0 +1,10 @@
+[fetcher_keystone]
+keystone_version = 3
+auth_section = keystone_authtoken
+region_name = {{ openstack_region_name }}
+
+{% if cloudkitty_collector_backend == "gnocchi" %}
+[collector_gnocchi]
+auth_section = keystone_authtoken
+region_name = {{ openstack_region_name }}
+{% endif %}


### PR DESCRIPTION
Required because of missing backport of https://review.opendev.org/#/c/699253/.

Can be reverted after the merge of https://review.opendev.org/#/c/725537/.