### PR TITLE
Add ussuri to the list of supported OpenStack releases

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -26,6 +26,7 @@ The following stable releases are supported. The development branch usually work
 * OpenStack Rocky
 * OpenStack Stein
 * OpenStack Train
+* OpenStack Ussuri
 
 Services
 ========

--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -146,10 +146,9 @@ glance_backend_ceph: "yes"
 gnocchi_backend_storage: "ceph"
 nova_backend_ceph: "yes"
 
-cinder_backup_driver: "ceph"
-
 ceph_gnocchi_pool_name: "metrics"
-
+ceph_nova_keyring: ceph.client.nova.keyring
+cinder_backup_driver: "ceph"
 glance_backend_file: "no"
 
 # NOTE: public_network from environments/ceph/configuration.yml


### PR DESCRIPTION
Ussuri will be the default of the testbed later.

Closes #200