### PR TITLE
watch target for terraform Makefile

### DIFF
--- a/heat/Makefile
+++ b/heat/Makefile
@@ -89,6 +89,10 @@ reset:
 
 # Watch the creation of the stack
 watch: .deploy.$(STACKNAME)
+	@DISP=0; \
+	if test "$$COLORTERM" = "1"; then \
+	  GREEN=$$(echo -e "\e[0;32m"); GREENBOLD=$$(echo -e "\e[1;32m"); BOLD=$$(echo -e "\e[0;1m"); RED=$$(echo -e "\e[0;31m"); YELLOW=$$(echo -e "\e[0;33m"); NORM=$$(echo -e "\e[0;0m"); \
+	fi; \
 	MGR_ADR=""; STAT=""; while true; do\
 		date; $(OPENSTACK) stack list; \
 		SRV=$$($(OPENSTACK) server list -f value -c "Name" -c "Status" | grep $(STACKNAME)-manager | cut -d ' ' -f2); \
@@ -99,11 +103,19 @@ watch: .deploy.$(STACKNAME)
 			MGR_ADR=$$($(OPENSTACK) stack output show $(STACKNAME) manager_address -f value -c output_value); \
 			echo "MANAGER_ADDRESS=$$MGR_ADR" > .MANAGER_ADDRESS.$(STACKNAME); \
 		fi; \
-		if test -n "$$MGR_ADR"; then ssh -o StrictHostKeyChecking=no -i .id_rsa.$(STACKNAME) ubuntu@$$MGR_ADR "sudo grep PLAY /var/log/cloud-init-output.log | grep -v 'PLAY \(\[\(Group hosts\|Gather facts\)\|RECAP\)' | tail -n3; sudo tail -n12 /var/log/cloud-init-output.log"; fi; \
+		if test -n "$$MGR_ADR"; then \
+			LEN=$$(ssh -o StrictHostKeyChecking=no -i .id_rsa.$(STACKNAME) ubuntu@$$MGR_ADR sudo wc -l /var/log/cloud-init-output.log 2>/dev/null); \
+			LEN=$${LEN%% *}; \
+			if test -n "$$LEN" -a "$$LEN" != "$$DISP"; then \
+			  OUT=$$(ssh -o StrictHostKeyChecking=no -i .id_rsa.$(STACKNAME) ubuntu@$$MGR_ADR sudo tail -n $$((LEN-DISP)) /var/log/cloud-init-output.log 2>/dev/null); \
+			  echo -e "$$OUT" | sed -e "s/^\(TASK.*\)$$/$$BOLD\1$$NORM/" -e "s/^\(PLAY.*\)$$/$$GREEN\1$$NORM/" -e "s/^\(The system is finally up.*\)$$/$$GREENBOLD\1$$NORM/" -e "s/\(FAILED\)/$$RED\1$$NORM/g" -e "s/\(failed=[1-9][0-9]*\|unreachable=[1-9][0-9]*\)/$$RED\1$$NORM/g" -e "s/\(warn\|WARN\|RETRYING\)/$$YELLOW\1$$NORM/" -e "s/\(ok:\|ok=[0-9]*\)/$$GREEN\1$$NORM/"; \
+			  DISP=$$LEN; \
+			fi; \
+		fi; \
 		STAT=$$($(OPENSTACK) stack list -f value -c "Stack Name" -c "Stack Status" | grep $(STACKNAME) | cut -d' ' -f2); \
 		if test "$$STAT" == "CREATE_COMPLETE"; then break; fi; \
 		if test "$$STAT" == "CREATE_FAILED"; then $(OPENSTACK) stack show $(STACKNAME) -f value -c "stack_status_reason"; break; fi; \
-		echo; sleep 30; \
+		sleep 10; \
 	done
 
 # Look for stack

--- a/heat/Makefile
+++ b/heat/Makefile
@@ -93,10 +93,12 @@ watch: .deploy.$(STACKNAME)
 	if test "$$COLORTERM" = "1"; then \
 	  GREEN=$$(echo -e "\e[0;32m"); GREENBOLD=$$(echo -e "\e[1;32m"); BOLD=$$(echo -e "\e[0;1m"); RED=$$(echo -e "\e[0;31m"); YELLOW=$$(echo -e "\e[0;33m"); NORM=$$(echo -e "\e[0;0m"); \
 	fi; \
-	MGR_ADR=""; STAT=""; while true; do\
-		date; $(OPENSTACK) stack list; \
-		SRV=$$($(OPENSTACK) server list -f value -c "Name" -c "Status" | grep $(STACKNAME)-manager | cut -d ' ' -f2); \
-		$(OPENSTACK) server list; \
+	date; $(OPENSTACK) stack list; \
+	MGR_ADR=""; STAT=""; while true; do \
+		if test "$$DISP" = "0"; then \
+			SRV=$$($(OPENSTACK) server list -f value -c "Name" -c "Status" | grep $(STACKNAME)-manager | cut -d ' ' -f2); \
+			$(OPENSTACK) server list; \
+		fi; \
 		if test -z "$$MGR_ADR" -a "$$SRV" = "ACTIVE"; then \
 			$(OPENSTACK) stack output show $(STACKNAME) private_key -f value -c output_value > .id_rsa.$(STACKNAME); \
 			chmod 0600 .id_rsa.$(STACKNAME); \

--- a/heat/Makefile
+++ b/heat/Makefile
@@ -105,6 +105,7 @@ watch: .deploy.$(STACKNAME)
 			MGR_ADR=$$($(OPENSTACK) stack output show $(STACKNAME) manager_address -f value -c output_value); \
 			echo "MANAGER_ADDRESS=$$MGR_ADR" > .MANAGER_ADDRESS.$(STACKNAME); \
 		fi; \
+		STAT=$$($(OPENSTACK) stack list -f value -c "Stack Name" -c "Stack Status" | grep $(STACKNAME) | cut -d' ' -f2); \
 		if test -n "$$MGR_ADR"; then \
 			LEN=$$(ssh -o StrictHostKeyChecking=no -i .id_rsa.$(STACKNAME) ubuntu@$$MGR_ADR sudo wc -l /var/log/cloud-init-output.log 2>/dev/null); \
 			LEN=$${LEN%% *}; \
@@ -114,11 +115,11 @@ watch: .deploy.$(STACKNAME)
 			  DISP=$$LEN; \
 			fi; \
 		fi; \
-		STAT=$$($(OPENSTACK) stack list -f value -c "Stack Name" -c "Stack Status" | grep $(STACKNAME) | cut -d' ' -f2); \
 		if test "$$STAT" == "CREATE_COMPLETE"; then break; fi; \
 		if test "$$STAT" == "CREATE_FAILED"; then $(OPENSTACK) stack show $(STACKNAME) -f value -c "stack_status_reason"; break; fi; \
-		sleep 10; \
-	done
+		sleep 5; \
+	done; \
+	date
 
 # Look for stack
 .deploy.$(STACKNAME):

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -73,4 +73,23 @@ console: .deploy.$(STACKNAME)
 	echo "$$PRIVATE_KEY" > $@; \
         chmod 0600 $@
 
-PHONY: clean console sshuttle ssh dry-run list create deploy deploy-infra deploy-ceph deploy-openstack
+watch: .id_rsa.$(STACKNAME) .MANAGER_ADDRESS.$(STACKNAME)
+	@source ./.MANAGER_ADDRESS.$(STACKNAME); \
+	DISP=0; \
+	if test "$$COLORTERM" = "1"; then \
+	  GREEN=$$(echo -e "\e[0;32m"); GREENBOLD=$$(echo -e "\e[1;32m"); BOLD=$$(echo -e "\e[0;1m"); RED=$$(echo -e "\e[0;31m"); YELLOW=$$(echo -e "\e[0;33m"); NORM=$$(echo -e "\e[0;0m"); \
+	fi; \
+	while true; do \
+		LEN=$$(ssh -o StrictHostKeyChecking=no -i .id_rsa.$(STACKNAME) ubuntu@$$MANAGER_ADDRESS sudo wc -l /var/log/cloud-init-output.log 2>/dev/null); \
+		LEN=$${LEN%% *}; \
+		if test -n "$$LEN" -a "$$LEN" != "$$DISP"; then \
+		  OUT=$$(ssh -o StrictHostKeyChecking=no -i .id_rsa.$(STACKNAME) ubuntu@$$MANAGER_ADDRESS sudo tail -n $$((LEN-DISP)) /var/log/cloud-init-output.log 2>/dev/null); \
+		  echo -e "$$OUT" | sed -e "s/^\(TASK.*\)$$/$$BOLD\1$$NORM/" -e "s/^\(PLAY.*\)$$/$$GREEN\1$$NORM/" -e "s/^\(The system is finally up.*\)$$/$$GREENBOLD\1$$NORM/" -e "s/\(FAILED\)/$$RED\1$$NORM/g" -e "s/\(failed=[1-9][0-9]*\|unreachable=[1-9][0-9]*\)/$$RED\1$$NORM/g" -e "s/\(warn\|WARN\|RETRYING\)/$$YELLOW\1$$NORM/" -e "s/\(ok:\|ok=[0-9]*\)/$$GREEN\1$$NORM/"; \
+		  if echo "$$OUT" | grep '^The system is finally up' >/dev/null 2>&1; then break; fi; \
+		  DISP=$$LEN; \
+		  sleep 5; \
+		fi; \
+	done;
+	#@$(OPENSTACK) server list
+
+PHONY: clean console sshuttle ssh dry-run list create deploy deploy-infra deploy-ceph deploy-openstack watch


### PR DESCRIPTION
We have a neat watch target in the heat Makefile, pulling the log file from the manager node, so we can follow the deployment (without accessing ARA).
Replicate this in the terraform framework.
As we need to parse the output to detect the completion (no wait condition here), we add a few more improvements:
- colorize the output (if COLORTERM=1)
- output all lines from the log
These improvements have been backported to the heat Makefile as well.