### PR TITLE
Use 11111111-1111-1111-1111-111111111111 as ceph fsid

### DIFF
--- a/environments/ceph/configuration.yml
+++ b/environments/ceph/configuration.yml
@@ -5,7 +5,7 @@
 containerized_deployment: true
 
 generate_fsid: false
-fsid: 00000000-0000-0000-0000-000000000000
+fsid: 11111111-1111-1111-1111-111111111111
 
 ##########################
 # osd

--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -189,7 +189,7 @@ security_sshd_allowed_macs: hmac-sha2-256,hmac-sha2-512,hmac-sha1
 # ceph
 
 ceph_share_directory: /share
-ceph_cluster_fsid: 00000000-0000-0000-0000-000000000000
+ceph_cluster_fsid: 11111111-1111-1111-1111-111111111111
 
 ##########################
 # cockpit


### PR DESCRIPTION
00000000-0000-0000-0000-000000000000 is not a valid fsid.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>