### PR TITLE
inventory: by default place storage service on the control nodes

### DIFF
--- a/inventory/20-roles
+++ b/inventory/20-roles
@@ -16,9 +16,6 @@ testbed-nodes
 [network:children]
 testbed-nodes
 
-[storage:children]
-testbed-nodes
-
 [ceph-control:children]
 testbed-nodes
 

--- a/inventory/50-kolla
+++ b/inventory/50-kolla
@@ -7,6 +7,9 @@
 # NOTE: only required when using Neutron DVR
 [external-compute]
 
+[storage:children]
+control
+
 [common:children]
 control
 network


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>