### PR TITLE
Remove debops parameters

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -1,16 +1,5 @@
 ---
 ##########################
-# debops
-
-# apt
-
-apt__enabled: no
-
-# grub
-
-grub_hidden_timeout: false
-
-##########################
 # configuration
 
 configuration_directory: /opt/configuration


### PR DESCRIPTION
Moved to the defaults of osism.ansible.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>