### PR TITLE
Remove network interfaces parameters

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -73,12 +73,6 @@ operator_group: dragon
 operator_authorized_keys: "{{lookup('file', '/share/id_rsa.pub')}}"
 
 ##########################
-# network
-
-network_allow_service_restart: no
-network_restart_method: nothing
-
-##########################
 # proxy
 
 proxy_proxies:


### PR DESCRIPTION
Moved to the defaults of osism.ansible.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>