### PR TITLE
Remove timezone parameter

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -60,11 +60,6 @@ sysdig_configure_repository: yes
 zabbix_agent_configure_repository: yes
 
 ##########################
-# timezone
-
-timezone_zone: UTC
-
-##########################
 # operator
 
 operator_user: dragon


### PR DESCRIPTION
Moved to the defaults of osism.ansible.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>