### PR TITLE
Remove chrony parameters

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -111,17 +111,6 @@ osism_serial:
   utilities: 100%
 
 ##########################
-# chrony
-
-chrony_servers:
-  - 1.de.pool.ntp.org
-  - 2.de.pool.ntp.org
-  - 3.de.pool.ntp.org
-  - 4.de.pool.ntp.org
-chrony_allowed_subnets:
-  - 127.0.0.1/32
-
-##########################
 # hardening
 
 stig_version: rhel7


### PR DESCRIPTION
Moved to the defaults of osism.ansible.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>