### PR TITLE
Remove operator parameters

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -39,9 +39,6 @@ repository_version: latest
 ##########################
 # operator
 
-operator_user: dragon
-operator_group: dragon
-
 operator_authorized_keys: "{{lookup('file', '/share/id_rsa.pub')}}"
 
 ##########################


### PR DESCRIPTION
Moved to the defaults of osism.ansible.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>