### PR TITLE
terraform: fix copy & paste syntax issue in Makefile

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -21,10 +21,10 @@ init:
 	@terraform workspace select ${ENVIRONMENT} || terraform workspace new ${ENVIRONMENT}
 
 attach: init
-        @terraform import -var-file="environment-$(ENVIRONMENT).tfvars" $(RESOURCE) $(PARAMS)
+	@terraform import -var-file="environment-$(ENVIRONMENT).tfvars" $(RESOURCE) $(PARAMS)
 
 detach: init
-        @terraform state rm $(RESOURCE) $(PARAMS)
+	@terraform state rm $(RESOURCE) $(PARAMS)
 
 dry-run: init
 	@terraform plan -var-file="environment-$(ENVIRONMENT).tfvars" $(PARAMS)


### PR DESCRIPTION
Makefile:27: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>