### PR TITLE
github: drop terraform 0.12.9 and use 0.13.4

### DIFF
--- a/.github/workflows/deploy-daily-citycloud.yml
+++ b/.github/workflows/deploy-daily-citycloud.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         terraform-version:
-          - 0.13.3
+          - 0.13.4
 
     steps:
       - name: Checkout

--- a/.github/workflows/validate-terraform.yml
+++ b/.github/workflows/validate-terraform.yml
@@ -17,8 +17,7 @@ jobs:
     strategy:
       matrix:
         terraform-version:
-          - 0.12.29
-          - 0.13.3
+          - 0.13.4
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>