### PR TITLE
docs: document the use of a different cloud provider name

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -84,6 +84,21 @@ each supported cloud provider.
 
      * The credentials are stored in ``clouds.yaml`` and ``secure.yaml`` with the name ``pluscloudopen``.
 
+.. note::
+
+   If the name of the cloud provider in ``clouds.yaml`` differs from the intended default, e.g.
+   ``betacloud`` for Betacloud, this can be adjusted as follows.
+
+   .. code-block:: console
+
+      PARAMS="-var 'cloudprovider=the-name-of-the-entry'"
+
+   A complete example with the environment for the Betacloud and a cloud provider with the name
+   ``the-name-of-the-entry`` looks like this:
+
+   .. code-block:: console
+
+      make deploy ENVIRONMENT=betacloud PARAMS="-var 'cloudprovider=the-name-of-the-entry'"
 
 Preparations
 ============


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>