### PR TITLE
* link Makefile ENVIRONMENT and terraform cloud_provider variables to…

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -18,6 +18,8 @@ ifeq ($(NEED_OSCLOUD),1)
   export OS_CLOUD=$(ENVIRONMENT)
 endif
 
+export TF_VAR_cloud_provider=$(ENVIRONMENT)
+
 ifneq (,$(wildcard ./minio.env))
   include minio.env
 endif

--- a/terraform/environment-betacloud.tfvars
+++ b/terraform/environment-betacloud.tfvars
@@ -1,3 +1,2 @@
-cloud_provider = "betacloud"
 image          = "Ubuntu 20.04"
 flavor_node    = "8C-32GB-40GB"

--- a/terraform/environment-betacloud.tfvars
+++ b/terraform/environment-betacloud.tfvars
@@ -1,2 +1,2 @@
-image          = "Ubuntu 20.04"
-flavor_node    = "8C-32GB-40GB"
+image       = "Ubuntu 20.04"
+flavor_node = "8C-32GB-40GB"

--- a/terraform/environment-citycloud.tfvars
+++ b/terraform/environment-citycloud.tfvars
@@ -1,4 +1,3 @@
-cloud_provider            = "citycloud"
 availability_zone         = "nova"
 volume_availability_zone  = "nova"
 network_availability_zone = "nova"

--- a/terraform/environment-ovh.tfvars
+++ b/terraform/environment-ovh.tfvars
@@ -1,4 +1,3 @@
-cloud_provider            = "ovh"
 availability_zone         = "nova"
 volume_availability_zone  = "nova"
 network_availability_zone = "nova"

--- a/terraform/environment-pluscloudopen.tfvars
+++ b/terraform/environment-pluscloudopen.tfvars
@@ -1,4 +1,3 @@
-cloud_provider            = "pluscloudopen"
 availability_zone         = "nova"
 volume_availability_zone  = "nova"
 network_availability_zone = "nova"

--- a/terraform/environment-scs-demo.tfvars
+++ b/terraform/environment-scs-demo.tfvars
@@ -1,4 +1,3 @@
-cloud_provider            = "scs-demo"
 availability_zone         = "nova"
 volume_availability_zone  = "nova"
 network_availability_zone = "nova"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,4 @@
 variable "cloud_provider" {
-  default = "betacloud"
   type    = string
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "cloud_provider" {
-  type    = string
+  type = string
 }
 
 variable "prefix" {


### PR DESCRIPTION
…gether to ensure outputs.tf creates the correct file for .MANAGER_ADDRESS.${var.cloud_provider}

* remove cloud_provider from environment tfvars aswell as default value from variables.tf

Signed-off-by: Ralf Heiringhoff <ralf.heiringhoff@plusserver.com>