### PR TITLE
Use protocol 112 instead of vrrp.

### DIFF
--- a/terraform/neutron.tf
+++ b/terraform/neutron.tf
@@ -83,7 +83,8 @@ resource "openstack_compute_secgroup_v2" "security_group_internal" {
 resource "openstack_networking_secgroup_rule_v2" "security_group_internal_vrrp" {
   direction         = "ingress"
   ethertype         = "IPv4"
-  protocol          = "vrrp"
+  #protocol          = "vrrp"
+  protocol          = "112"
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_compute_secgroup_v2.security_group_internal.id
 }

--- a/terraform/neutron.tf
+++ b/terraform/neutron.tf
@@ -83,8 +83,7 @@ resource "openstack_compute_secgroup_v2" "security_group_internal" {
 resource "openstack_networking_secgroup_rule_v2" "security_group_internal_vrrp" {
   direction         = "ingress"
   ethertype         = "IPv4"
-  #protocol          = "vrrp"
-  protocol          = "112"
+  protocol          = "112" # vrrp
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_compute_secgroup_v2.security_group_internal.id
 }


### PR DESCRIPTION
This is the same, but not all versions of neutron recognize vrrp.
This is required for OTC, but is harmless elsewhere.

Signed-off-by: Kurt Garloff <kurt@garloff.de>