### PR TITLE
Generalize override mechanism.

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -147,6 +147,18 @@ With the file ``environments/CLOUDPROVIDER.tfvars`` the parameters of the enviro
    image       = "OSISM base"
    flavor_node = "8C-32GB-40GB"
 
+Beyond the terraform variables, you can enable special overrides by adding special
+comments into the .tfvars files. The syntax is ``# override:XXXX``. This will
+include the file ``overrides/XXXX_override.tf`` into the terraform deployment.
+
+Currently two such overrides exist:
+
+* ``neutron_availability_zone_hints``: This enables using network availability zone hints.
+  betacloud and citycloud benefit from this.
+* ``neutron_router_enable_snat``: This passes ``enable_snat: true`` for the router. This is
+  required by OTC.
+
+
 Local Environment
 =================
 

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -27,22 +27,10 @@ init:
 	@terraform workspace select ${ENVIRONMENT} || terraform workspace new ${ENVIRONMENT}
 
 	@rm -f *_override.tf
-
-	@if test "$$ENVIRONMENT" = "betacloud"; then \
-	  cp overrides/neutron_availability_zone_hints_override.tf neutron_availability_zone_hints_override.tf; \
-	fi
-
-	@if test "$$ENVIRONMENT" = "citycloud"; then \
-	  cp overrides/neutron_availability_zone_hints_override.tf neutron_availability_zone_hints_override.tf; \
-	fi
-
-	@if test "$$ENVIRONMENT" = "otc"; then \
-	  cp overrides/neutron_router_enable_snat_override.tf neutron_router_enable_snat_override.tf; \
-	fi
-
-	@if test "$$ENVIRONMENT" = "otc-physical"; then \
-	  cp overrides/neutron_router_enable_snat_override.tf neutron_router_enable_snat_override.tf; \
-	fi
+	@for over in `grep '^# *override:' "environments/${ENVIRONMENT}.tfvars" | sed 's/^# *override://'`; do \
+		echo $$over; \
+		cp -p overrides/$${over}_override.tf .; \
+	done
 
 attach: init
 	@terraform import -var-file="environments/$(ENVIRONMENT).tfvars" $(RESOURCE) $(PARAMS)

--- a/terraform/environments/betacloud.tfvars
+++ b/terraform/environments/betacloud.tfvars
@@ -1,2 +1,3 @@
+# override:neutron_availability_zone_hints
 image       = "Ubuntu 20.04"
 flavor_node = "8C-32GB-40GB"

--- a/terraform/environments/citycloud.tfvars
+++ b/terraform/environments/citycloud.tfvars
@@ -1,3 +1,4 @@
+# override:neutron_availability_zone_hints
 availability_zone         = "nova"
 volume_availability_zone  = "nova"
 network_availability_zone = "nova"


### PR DESCRIPTION
The overrides are controlled by comments in the envinroment files
now. You can add # override:XXXX in the environments files to include
overrides/XXXX_override.tf into your deployment.

This is used by betacloud and citycloud (neutron_availability_zone_hints)
and will be used by otc (neutron_router_enable_snat).

Signed-off-by: Kurt Garloff <kurt@garloff.de>