### PR TITLE
custom: do not write ceph keys to glance-api directory

### DIFF
--- a/environments/custom/playbook-fetch-ceph-keys.yml
+++ b/environments/custom/playbook-fetch-ceph-keys.yml
@@ -25,9 +25,6 @@
       - src: ceph.client.glance.keyring
         dest: "{{ configuration_directory }}/environments/kolla/files/overlays/glance/ceph.client.glance.keyring"
 
-      - src: ceph.client.glance.keyring
-        dest: "{{ configuration_directory }}/environments/kolla/files/overlays/glance-api/ceph.client.glance.keyring"
-
       - src: ceph.client.gnocchi.keyring
         dest: "{{ configuration_directory }}/environments/kolla/files/overlays/gnocchi/ceph.client.gnocchi.keyring"
 


### PR DESCRIPTION
Closes #638

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>