### PR TITLE
terraform: fix syntax of minio.tf.disabled

### DIFF
--- a/terraform/minio.tf.disabled
+++ b/terraform/minio.tf.disabled
@@ -1,11 +1,11 @@
 terraform {
   backend "s3" {
-    bucket = "terraform-testbed"
-    key = "terraform.tfstate"
-    region = "main"
-    force_path_style = true
+    bucket                      = "terraform-testbed"
+    key                         = "terraform.tfstate"
+    region                      = "main"
+    force_path_style            = true
     skip_credentials_validation = true
-    skip_metadata_api_check = true
-    skip_region_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
   }
 }


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>