### PR TITLE
inventory: use node_id only for the network configuration

### DIFF
--- a/inventory/host_vars/testbed-manager.osism.test.yml
+++ b/inventory/host_vars/testbed-manager.osism.test.yml
@@ -17,8 +17,8 @@ netbox_inventory_status: Active
 console_interface: "{{ ansible_local.testbed_network_devices.management }}"
 management_interface: "{{ ansible_local.testbed_network_devices.management }}"
 
-internal_address: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
-fluentd_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+internal_address: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(5) | ipaddr('address') }}"
+fluentd_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(5) | ipaddr('address') }}"
 
 ##########################################################
 # cockpit

--- a/inventory/host_vars/testbed-node-0.osism.test.yml
+++ b/inventory/host_vars/testbed-node-0.osism.test.yml
@@ -17,8 +17,8 @@ netbox_inventory_status: Active
 console_interface: "{{ ansible_local.testbed_network_devices.management }}"
 management_interface: "{{ ansible_local.testbed_network_devices.management }}"
 
-internal_address: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
-fluentd_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+internal_address: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(10) | ipaddr('address') }}"
+fluentd_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(10) | ipaddr('address') }}"
 
 ##########################################################
 # cockpit
@@ -67,9 +67,9 @@ neutron_external_interface: vxlan0
 # ceph
 
 # monitor_interface:
-monitor_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+monitor_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(10) | ipaddr('address') }}"
 # radosgw_interface:
-radosgw_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+radosgw_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(10) | ipaddr('address') }}"
 
 devices: "{{ ansible_local.testbed_ceph_devices }}"
 

--- a/inventory/host_vars/testbed-node-1.osism.test.yml
+++ b/inventory/host_vars/testbed-node-1.osism.test.yml
@@ -17,8 +17,8 @@ netbox_inventory_status: Active
 console_interface: "{{ ansible_local.testbed_network_devices.management }}"
 management_interface: "{{ ansible_local.testbed_network_devices.management }}"
 
-internal_address: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
-fluentd_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+internal_address: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(11) | ipaddr('address') }}"
+fluentd_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(11) | ipaddr('address') }}"
 
 ##########################################################
 # cockpit
@@ -67,9 +67,9 @@ neutron_external_interface: vxlan0
 # ceph
 
 # monitor_interface:
-monitor_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+monitor_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(11) | ipaddr('address') }}"
 # radosgw_interface:
-radosgw_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+radosgw_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(11) | ipaddr('address') }}"
 
 devices: "{{ ansible_local.testbed_ceph_devices }}"
 

--- a/inventory/host_vars/testbed-node-2.osism.test.yml
+++ b/inventory/host_vars/testbed-node-2.osism.test.yml
@@ -17,8 +17,8 @@ netbox_inventory_status: Active
 console_interface: "{{ ansible_local.testbed_network_devices.management }}"
 management_interface: "{{ ansible_local.testbed_network_devices.management }}"
 
-internal_address: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
-fluentd_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+internal_address: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(12) | ipaddr('address') }}"
+fluentd_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(12) | ipaddr('address') }}"
 
 ##########################################################
 # cockpit
@@ -67,9 +67,9 @@ neutron_external_interface: vxlan0
 # ceph
 
 # monitor_interface:
-monitor_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+monitor_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(12) | ipaddr('address') }}"
 # radosgw_interface:
-radosgw_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+radosgw_address: "{{ '192.168.64.0/20' | ipaddr('net') | ipaddr(12) | ipaddr('address') }}"
 
 devices: "{{ ansible_local.testbed_ceph_devices }}"
 


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>