### PR TITLE
inventory: use node_id only for the network configuration (pt. 2)

### DIFF
--- a/inventory/host_vars/testbed-manager.osism.test.yml
+++ b/inventory/host_vars/testbed-manager.osism.test.yml
@@ -4,7 +4,7 @@ node_id: 5
 ##########################################################
 # ansible
 
-ansible_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+ansible_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(5) | ipaddr('address') }}"
 
 ##########################################################
 # netbox

--- a/inventory/host_vars/testbed-node-0.osism.test.yml
+++ b/inventory/host_vars/testbed-node-0.osism.test.yml
@@ -4,7 +4,7 @@ node_id: 10
 ##########################################################
 # ansible
 
-ansible_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+ansible_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(10) | ipaddr('address') }}"
 
 ##########################################################
 # netbox

--- a/inventory/host_vars/testbed-node-1.osism.test.yml
+++ b/inventory/host_vars/testbed-node-1.osism.test.yml
@@ -4,7 +4,7 @@ node_id: 11
 ##########################################################
 # ansible
 
-ansible_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+ansible_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(11) | ipaddr('address') }}"
 
 ##########################################################
 # netbox

--- a/inventory/host_vars/testbed-node-2.osism.test.yml
+++ b/inventory/host_vars/testbed-node-2.osism.test.yml
@@ -4,7 +4,7 @@ node_id: 12
 ##########################################################
 # ansible
 
-ansible_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"
+ansible_host: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(12) | ipaddr('address') }}"
 
 ##########################################################
 # netbox


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>