### PR TITLE
Remove commented mitogen sample configuration

### DIFF
--- a/environments/ansible.cfg
+++ b/environments/ansible.cfg
@@ -22,10 +22,6 @@ private_key_file = /ansible/secrets/id_rsa.operator
 retry_files_enabled = false
 roles_path = /ansible/roles:/ansible/galaxy
 
-# strategy
-# strategy_plugins = /ansible/plugins/mitogen/ansible_mitogen/plugins/strategy
-# strategy = mitogen_linear
-
 # Fact caching
 gathering = smart
 fact_caching = redis


### PR DESCRIPTION
Mitogen plugins have been removed from Ansible containers.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>