### PR TITLE
docs: add pacific to the list of supported ceph releases

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -27,6 +27,7 @@ Ceph
 * Luminous
 * Nautilus
 * Octopus (**default**)
+* Pacific
 
 OpenStack
 ---------


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>