### PR TITLE
Always use vxlan0 as provider network in testbed_network_devices.fact

### DIFF
--- a/environments/custom/files/testbed_network_devices.fact
+++ b/environments/custom/files/testbed_network_devices.fact
@@ -39,9 +39,7 @@ for interface in netifaces.interfaces():
                 if addr['addr'].startswith(NETWORKS[network]):
                     result[network] = interface
 
-    # NOTE: After a reboot of the nodes the provider network has
-    #       no more IP configuration.
-    else:
-        result['provider'] = interface
+# NOTE: vxlan is always used as provider network.
+result['provider'] = 'vxlan0'
 
 print(json.dumps(result))


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>