### PR TITLE
workaround: set mon auth_allow_insecure_global_id_reclaim to false vi…

### DIFF
--- a/environments/custom/playbook-workarounds.yml
+++ b/environments/custom/playbook-workarounds.yml
@@ -93,3 +93,18 @@
       service:
         name: workarounds
         enabled: true
+
+- name: Fix 'insecure global_id reclaim' ceph health warning
+  hosts: manager
+  gather_facts: false
+
+  tasks:
+
+    # NOTE: This temporarily solves the following problems:
+    #
+    #       client is using insecure global_id reclaim
+    #       mons are allowing insecure global_id reclaim
+
+    - name: Fix 'insecure global_id reclaim' ceph health warning
+      command: ceph config set mon auth_allow_insecure_global_id_reclaim false
+      changed_when: false


### PR DESCRIPTION
…a CLI

The fix of 0dd966d42da305d26233f5fd1a3e6d891ef506b4 did not work properly.
So now a temporary workaround for the warnings.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>