### PR TITLE
ceph: do not apply workarounds

### DIFF
--- a/environments/ceph/configuration.yml
+++ b/environments/ceph/configuration.yml
@@ -223,7 +223,6 @@ ceph_conf_overrides:
 
   mon:
     mon allow pool delete: true
-    mon auth_allow_insecure_global_id_reclaim: false
 
   "client.rgw.{{ hostvars[inventory_hostname]['ansible_hostname'] }}.rgw0":
     "rgw content length compat": "true"

--- a/scripts/003-ceph-services.sh
+++ b/scripts/003-ceph-services.sh
@@ -6,5 +6,4 @@ osism-ceph testbed
 osism-ceph rgws
 osism-run custom fetch-ceph-keys
 osism-infrastructure cephclient
-osism-run custom workarounds-ceph
 osism-run custom bootstrap-ceph-dashboard


### PR DESCRIPTION
Setting auth_allow_insecure_global_id_reclaim to false breaks old ceph clients.

(glance-api)[glance@testbed-node-0 /]$ ceph -k /etc/ceph/ceph.client.glance.keyring -n client.glance -s
2021-06-28T17:48:09.215+0000 7efcd2ffd700 -1 monclient(hunting): handle_auth_bad_method server allowed_methods [2] but i only support [2,1]
2021-06-28T17:48:09.231+0000 7efcd37fe700 -1 monclient(hunting): handle_auth_bad_method server allowed_methods [2] but i only support [2,1]
[errno 13] RADOS permission denied (error connecting to the cluster)

Signed-off-by: Christian Berendt <berendt@osism.tech>