### PR TITLE
Revert "kolla: do not enable sanity checks by default"

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -7,6 +7,11 @@ openstack_release: victoria
 kolla_image_version: "{{ openstack_release }}"
 
 ##########################################################
+# kolla
+
+kolla_enable_sanity_checks: "yes"
+
+##########################################################
 # haproxy
 
 kolla_internal_fqdn: api-int.osism.test


### PR DESCRIPTION
This reverts commit db63ac2e0a85b47e6c047807b90b58bfd6a80a2e.

Signed-off-by: Christian Berendt <berendt@osism.tech>