### PR TITLE
custom: use hwinfo instead of lsblk to find available block devices

### DIFF
--- a/environments/custom/files/testbed_ceph_devices.fact
+++ b/environments/custom/files/testbed_ceph_devices.fact
@@ -16,7 +16,7 @@ partition = os.path.basename(result.stdout.strip())
 result = run("basename $(readlink -f '/sys/class/block/%s/..')" % partition, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
 root = result.stdout.strip()
 
-result = run("lsblk -nd -I 8,220,252 --output NAME | sort | grep -v %s" % root, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
+result = run("hwinfo --disk --short | grep Disk | awk '{print $1}' | xargs -n1 basename | sort | grep -v %s" % root, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
 devices = result.stdout.strip().split("\n")
 
 print(json.dumps(["/dev/%s" % x for x in devices[:-1]]))

--- a/environments/custom/files/testbed_ceph_devices_all.fact
+++ b/environments/custom/files/testbed_ceph_devices_all.fact
@@ -16,7 +16,7 @@ partition = os.path.basename(result.stdout.strip())
 result = run("basename $(readlink -f '/sys/class/block/%s/..')" % partition, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
 root = result.stdout.strip()
 
-result = run("lsblk -nd -I 8,220,252 --output NAME | sort | grep -v %s" % root, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
+result = run("hwinfo --disk --short | grep Disk | awk '{print $1}' | xargs -n1 basename | sort | grep -v %s" % root, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True)
 devices = result.stdout.strip().split("\n")
 
 print(json.dumps(["/dev/%s" % x for x in devices]))

--- a/environments/custom/playbook-facts.yml
+++ b/environments/custom/playbook-facts.yml
@@ -5,28 +5,34 @@
 
   tasks:
     - name: Install python3-netifaces package
+      become: true
       apt:
         name: python3-netifaces
         state: present
+
+    - name: Install hwinfo package
       become: true
+      apt:
+        name: hwinfo
+        state: present
 
     - name: Create custom facts directory
+      become: true
       file:
         path: /etc/ansible/facts.d
         state: "directory"
         owner: root
         group: root
         mode: 0755
-      become: true
 
     - name: Copy fact files
+      become: true
       copy:
         src: "{{ item }}.fact"
         dest: "/etc/ansible/facts.d/{{ item }}.fact"
         owner: root
         group: root
         mode: 0755
-      become: true
       loop:
         - testbed_ceph_devices
         - testbed_ceph_devices_all


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>