### PR TITLE
terraform: reduce the number of BMS nodes on the OTC to 3

### DIFF
--- a/terraform/environments/otcbms.tfvars
+++ b/terraform/environments/otcbms.tfvars
@@ -13,4 +13,4 @@ volume_size_base          = "40"
 public                    = "admin_external_net"
 enable_dhcp               = "true"
 dns_nameservers           = ["100.125.4.25", "9.9.9.9"]
-number_of_nodes           = 10
+number_of_nodes           = 3


### PR DESCRIPTION
There are very few BMS instances in the OTC. Therefore, the
number used must be reduced.

Signed-off-by: Christian Berendt <berendt@osism.tech>