### PR TITLE
docs: fix default ceph version

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -26,8 +26,8 @@ Ceph
 
 * Luminous
 * Nautilus
-* Octopus (**default**)
-* Pacific
+* Octopus
+* Pacific (**default**)
 
 OpenStack
 ---------


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>