### PR TITLE
Do not enable magnum by default

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -564,4 +564,4 @@ This section describes how individual parts of the testbed can be deployed.
 
   .. code-block:: console
 
-     osism-kolla deploy heat,gnocchi,ceilometer,aodh,panko,magnum,barbican,designate
+     osism-kolla deploy heat,gnocchi,ceilometer,aodh,panko,barbican,designate

--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -30,7 +30,6 @@ enable_cinder_backup: "yes"
 enable_designate: "yes"
 enable_gnocchi: "yes"
 enable_heat: "yes"
-enable_magnum: "yes"
 enable_manila: "yes"
 enable_octavia: "yes"
 enable_panko: "yes"
@@ -105,9 +104,6 @@ ceilometer_event_type: panko
 
 # designate
 designate_ns_record: openstack.osism.test
-
-# magnum
-enable_cluster_user_trust: "yes"
 
 # manila
 enable_manila_backend_generic: "yes"

--- a/scripts/007-openstack-services-extented.sh
+++ b/scripts/007-openstack-services-extented.sh
@@ -10,6 +10,3 @@ osism-kolla deploy panko
 osism-kolla deploy heat
 osism-kolla deploy barbican
 osism-kolla deploy senlin
-
-osism-kolla deploy magnum
-osism-run openstack bootstrap-magnum


### PR DESCRIPTION
There are no plans to offer the Magnum service in OSISM. Gardener should be used instead.

Signed-off-by: Christian Berendt <berendt@osism.tech>