### PR TITLE
Fix role name typo in Ceph rgw configuration

### DIFF
--- a/environments/ceph/configuration.yml
+++ b/environments/ceph/configuration.yml
@@ -225,7 +225,7 @@ ceph_conf_overrides:
   "client.rgw.{{ hostvars[inventory_hostname]['ansible_hostname'] }}.rgw0":
     "rgw content length compat": "true"
     "rgw enable apis": "swift, s3"
-    "rgw keystone accepted roles": "Member, _member_, admin"
+    "rgw keystone accepted roles": "member, _member_, admin"
     "rgw keystone accepted admin roles": "admin"
     "rgw keystone admin domain": "default"
     "rgw keystone admin password": "hF6NWPG4rWTpK00oANEcRAiKbwbEcKFHHYYskar2"


### PR DESCRIPTION
Signed-off-by: Uwe Grawert <grawert@b1-systems.de>