### PR TITLE
Do not deploy wireguard by default

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -8,7 +8,7 @@ Usage
 Wireguard
 =========
 
-* deployment (Wireguard is rolled out by default)
+* deployment
 
   .. code-block:: console
 

--- a/scripts/001-helper-services.sh
+++ b/scripts/001-helper-services.sh
@@ -4,6 +4,5 @@ export INTERACTIVE=false
 
 osism-infrastructure sshconfig
 osism-run custom generate-ssh-known-hosts
-osism-run custom wireguard
 osism-generic dotfiles
 osism-infrastructure homer


### PR DESCRIPTION
sshuttle can be used as a default solution.

Wireguard and in the future tailscale as alternatives.

Signed-off-by: Christian Berendt <berendt@osism.tech>