### PR TITLE
Move Operator role as 1st operation in Bootstrap node - pt. 2 Section

### DIFF
--- a/terraform/files/node.yml
+++ b/terraform/files/node.yml
@@ -71,6 +71,7 @@
     - osism.services
 
   roles:
+    - role: operator
     - role: chrony
     - role: configfs
     - role: packages
@@ -80,7 +81,6 @@
     - role: hddtemp
     - role: rng
     - role: cleanup
-    - role: operator
 
 - name: Apply role docker
   hosts: localhost


### PR DESCRIPTION
Signed-off-by: Mathias Fechner <mathias.fechner@plusserver.com>

in ovn context their is strange behavior (can't install  packages, in cause of missing user dragon)
in new sequence  it works
