### PR TITLE
- fix cloud-init WARNING during bootup

### DIFF
--- a/terraform/manager.tf
+++ b/terraform/manager.tf
@@ -113,11 +113,11 @@ write_files:
   - content: |
       ${indent(6, file("files/node.sh"))}
     path: /root/node.sh
-    permissions: 0700
+    permissions: '0700'
   - content: |
       ${indent(6, file("files/manager.sh"))}
     path: /root/manager.sh
-    permissions: 0700
+    permissions: '0700'
   - content: |
       #!/usr/bin/env bash
 
@@ -137,7 +137,7 @@ write_files:
       bash /root/manager.sh
 
     path: /root/run-manager.sh
-    permissions: 0700
+    permissions: '0700'
 runcmd:
   - "echo 'network: {config: disabled}' > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg"
   - "rm -f /etc/network/interfaces.d/50-cloud-init.cfg"


### PR DESCRIPTION
--------------cut-----------
2021-11-15 14:53:25,268 - schema.py[WARNING]: Invalid config:
write_files.9.permissions: 448 is not of type 'string'
write_files.10.permissions: 448 is not of type 'string'
write_files.11.permissions: 448 is not of type 'string'
--------------cut-----------