### PR TITLE
kolla: use nova as nova ceph user

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -130,9 +130,11 @@ gnocchi_backend_storage: "ceph"
 nova_backend_ceph: "yes"
 
 ceph_gnocchi_pool_name: "metrics"
-ceph_nova_keyring: ceph.client.nova.keyring
 cinder_backup_driver: "ceph"
 glance_backend_file: "no"
+
+ceph_nova_user: nova
+ceph_nova_keyring: ceph.client.nova.keyring
 
 # NOTE: public_network from environments/ceph/configuration.yml
 ceph_public_network: 192.168.64.0/20


### PR DESCRIPTION
The upstream default has changed from nova to cinder.
We will stay with nova for now.

Signed-off-by: Christian Berendt <berendt@osism.tech>