### PR TITLE
ceph: re-add openstack_config

### DIFF
--- a/environments/ceph/configuration.yml
+++ b/environments/ceph/configuration.yml
@@ -20,6 +20,13 @@ public_network: 192.168.16.0/20
 cluster_network: 192.168.16.0/20
 
 ##########################
+# openstack
+
+# NOTE: After the initial deployment of the Ceph Clusters, the following parameter can be
+#       set to false. It must only be set to true again when new pools or keys are added.
+openstack_config: true
+
+##########################
 # custom
 
 ceph_conf_overrides:


### PR DESCRIPTION
Was accidentally removed with 3ac55e4645e582061a50ea244390d82a7c60821e.

Signed-off-by: Christian Berendt <berendt@osism.tech>