### PR TITLE
Pass -Dlog4j2.formatMsgNoLookups=true to ElasticSearch.

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -54,6 +54,7 @@ enable_osprofiler: "no"
 # elasticsearch
 
 es_heap_size: "1g"
+es_java_opts: "-Dlog4j2.formatMsgNoLookups=true {% if es_heap_size %}-Xms{{ es_heap_size }} -Xmx{{ es_heap_size }}{%endif%}"
 
 # grafana
 


### PR DESCRIPTION
Even though testbed is not meant for productive deployments, we should
still secure it against the log4j issue (CVE-2021-44228), which affects
the ElasticSearch containers that are deployed on the compute nodes.

The final solution will be the deployment of a new ES container built
with updated (>=2.16) log4j, but this allows us to be secure for now.
(Note: The parameter is harmless even after updating log4j, so no risk
 here. We can lazily clean it up at some point though.)

See our security advisory https://scs.community/2021/12/13/advisory-log4j/
for more details.

Signed-off-by: Kurt Garloff <scs@garloff.de>