### PR TITLE
Set docker_network_mtu according to testbed environment

### DIFF
--- a/inventory/group_vars/testbed-managers.yml
+++ b/inventory/group_vars/testbed-managers.yml
@@ -27,6 +27,7 @@ management_interface: "{{ internal_interface }}"
 # docker
 
 docker_allow_restart: false
+docker_network_mtu: "{{ testbed_mtu_manager }}"
 
 ##########################################################
 # netdata

--- a/inventory/group_vars/testbed-nodes.yml
+++ b/inventory/group_vars/testbed-nodes.yml
@@ -18,6 +18,11 @@ netbox_inventory_tags:
   - ceph-resource
 
 ##########################################################
+# docker
+
+docker_network_mtu: "{{ testbed_mtu_node }}"
+
+##########################################################
 # generic
 
 internal_address: "{{ '192.168.16.0/20' | ipaddr('net') | ipaddr(node_id) | ipaddr('address') }}"


### PR DESCRIPTION
When running inside a virtualized environment, docker-compose needs to
be told the smaller MTU for each container it creates.

Closes: #912

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>