### PR TITLE
Remove homer from 001-helper-services.sh

### DIFF
--- a/scripts/001-helper-services.sh
+++ b/scripts/001-helper-services.sh
@@ -5,4 +5,3 @@ export INTERACTIVE=false
 osism apply sshconfig
 osism-run custom generate-ssh-known-hosts
 osism apply dotfiles
-osism apply homer


### PR DESCRIPTION
It is also part of 002-infrastructure-services-basic.sh.

Signed-off-by: Christian Berendt <berendt@osism.tech>