### PR TITLE
Base install is ~20GB on mgr and nodes, need more space.

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,7 +19,7 @@ variable "image_node" {
 
 variable "volume_size_base" {
   type    = number
-  default = 20
+  default = 30
 }
 
 variable "volume_size_storage" {


### PR DESCRIPTION
With 30GB, we have some room for addtl. containers and logs.

Signed-off-by: Kurt Garloff <kurt@garloff.de>