### PR TITLE
netbox: do not validate certs

### DIFF
--- a/netbox/playbook-init.yml
+++ b/netbox/playbook-init.yml
@@ -12,6 +12,7 @@
       netbox_site:
         netbox_url: "{{ netbox_url }}"
         netbox_token: "{{ netbox_token }}"
+        validate_certs: "no"
         data:
           name: Discworld
           slug: discworld
@@ -21,6 +22,7 @@
       netbox_location:
         netbox_url: "{{ netbox_url }}"
         netbox_token: "{{ netbox_token }}"
+        validate_certs: "no"
         data:
           name: Ankh-Morpork
           slug: ankh-morpork

--- a/netbox/playbook-rack-1000.yml
+++ b/netbox/playbook-rack-1000.yml
@@ -17,6 +17,7 @@
       netbox_rack:
         netbox_url: "{{ netbox_url }}"
         netbox_token: "{{ netbox_token }}"
+        validate_certs: "no"
         data:
           name: "{{ rack }}"
           site: "{{ site }}"
@@ -27,6 +28,7 @@
       netbox_device:
         netbox_url: "{{ netbox_url }}"
         netbox_token: "{{ netbox_token }}"
+        validate_certs: "no"
         data:
           name: testbed-switch-1
           site: "{{ site }}"
@@ -42,6 +44,7 @@
       netbox_device:
         netbox_url: "{{ netbox_url }}"
         netbox_token: "{{ netbox_token }}"
+        validate_certs: "no"
         data:
           name: testbed-manager
           site: "{{ site }}"
@@ -59,6 +62,7 @@
       netbox_device:
         netbox_url: "{{ netbox_url }}"
         netbox_token: "{{ netbox_token }}"
+        validate_certs: "no"
         data:
           name: testbed-node-0
           site: "{{ site }}"
@@ -76,6 +80,7 @@
       netbox_device:
         netbox_url: "{{ netbox_url }}"
         netbox_token: "{{ netbox_token }}"
+        validate_certs: "no"
         data:
           name: testbed-node-1
           site: "{{ site }}"
@@ -93,6 +98,7 @@
       netbox_device:
         netbox_url: "{{ netbox_url }}"
         netbox_token: "{{ netbox_token }}"
+        validate_certs: "no"
         data:
           name: testbed-node-2
           site: "{{ site }}"


### PR DESCRIPTION
Since we use the Netbox internally with Traefik and self-signed
certificates, we do not validate them.

Signed-off-by: Christian Berendt <berendt@osism.tech>