### PR TITLE
Require terraform 1.0.0 because of HCP

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.0.0"
 
   required_providers {
     local = {


### PR DESCRIPTION
HCP currently only offers 1.0.9.

Partly revert of 384ef2d2b5bdea7744e80c839bde9fa5046ce77e.

Signed-off-by: Christian Berendt <berendt@osism.tech>