### PR TITLE
netbox: add managed-by-osism tag to testbed-switch-0

### DIFF
--- a/netbox/playbooks/rack-1000.yml
+++ b/netbox/playbooks/rack-1000.yml
@@ -38,6 +38,8 @@
           device_role: Mixed
           face: rear
           position: 1
+          tags:
+            - managed-by-osism
         state: present
 
     - name: Manage testbed-manager


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>