### PR TITLE
Add missing operator_user

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -23,6 +23,7 @@ docker_registry_service: index.docker.io
 ##########################
 # operator
 
+operator_user: dragon
 operator_authorized_keys:
   - "{{lookup('file', '/ansible/secrets/id_rsa.operator.pub')}}"
 


### PR DESCRIPTION
This parameter is required by environments/manager/run.sh

Signed-off-by: Christian Berendt <berendt@osism.tech>