### PR TITLE
Stop running kolla sanity checks #1064

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -5,11 +5,6 @@
 docker_registry: quay.io
 
 ##########################################################
-# kolla
-
-kolla_enable_sanity_checks: "yes"
-
-##########################################################
 # haproxy
 
 kolla_internal_fqdn: api-int.testbed.osism.xyz


### PR DESCRIPTION
We want to deprecated and remove them, as they are not tested in the
upstream CI and there are regressions in Xena, so stop running them
completely.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>