### PR TITLE
inventory: do not use ipaddr

### DIFF
--- a/inventory/group_vars/testbed-managers.yml
+++ b/inventory/group_vars/testbed-managers.yml
@@ -12,7 +12,7 @@ netbox_inventory_tags:
 ##########################################################
 # generic
 
-internal_address: "{{ '192.168.16.0/20' | ansible.netcommon.ipaddr('net') | ansible.netcommon.ipaddr(node_id) | ansible.netcommon.ipaddr('address') }}"
+internal_address: "192.168.16.{{ node_id }}"
 internal_interface: "{{ ansible_local.testbed_network_devices.management }}"
 
 console_interface: "{{ internal_interface }}"
@@ -36,8 +36,8 @@ network_type: netplan
 network_ethernets:
   "{{ ansible_local.testbed_network_devices.management }}":
     addresses:
-      - "{{ '192.168.16.0/20' | ansible.netcommon.ipaddr('net') | ansible.netcommon.ipaddr(node_id) | ansible.netcommon.ipaddr('address') }}/20"
-    gateway4: "{{ '192.168.16.0/20' | ansible.netcommon.ipaddr('net') | ansible.netcommon.ipaddr('1') | ansible.netcommon.ipaddr('address') }}"
+      - "192.168.16.{{ node_id }}/20"
+    gateway4: "192.168.16.1"
     mtu: "{{ testbed_mtu_manager }}"
 network_dispatcher_scripts:
   - src: /opt/configuration/network/vxlan.sh

--- a/inventory/group_vars/testbed-nodes.yml
+++ b/inventory/group_vars/testbed-nodes.yml
@@ -20,7 +20,7 @@ docker_network_mtu: "{{ testbed_mtu_node }}"
 ##########################################################
 # generic
 
-internal_address: "{{ '192.168.16.0/20' | ansible.netcommon.ipaddr('net') | ansible.netcommon.ipaddr(node_id) | ansible.netcommon.ipaddr('address') }}"
+internal_address: "192.168.16.{{ node_id }}"
 internal_interface: "{{ ansible_local.testbed_network_devices.management }}"
 
 console_interface: "{{ internal_interface }}"
@@ -39,8 +39,8 @@ network_type: netplan
 network_ethernets_virtual:
   "{{ ansible_local.testbed_network_devices.management }}":
     addresses:
-      - "{{ '192.168.16.0/20' | ansible.netcommon.ipaddr('net') | ansible.netcommon.ipaddr(node_id) | ansible.netcommon.ipaddr('address') }}/20"
-    gateway4: "{{ '192.168.16.0/20' | ansible.netcommon.ipaddr('net') | ansible.netcommon.ipaddr('1') | ansible.netcommon.ipaddr('address') }}"
+      - "192.168.16.{{ node_id }}/20"
+    gateway4: "192.168.16.1"
     mtu: "{{ testbed_mtu_node }}"
 
 # NOTE: On OTC BMS nodes, the virtualization_role is set to host. On these nodes we want to
@@ -62,8 +62,8 @@ octavia_network_interface: ohm0
 ##########################################################
 # ceph
 
-monitor_address: "{{ '192.168.16.0/20' | ansible.netcommon.ipaddr('net') | ansible.netcommon.ipaddr(node_id) | ansible.netcommon.ipaddr('address') }}"
-radosgw_address: "{{ '192.168.16.0/20' | ansible.netcommon.ipaddr('net') | ansible.netcommon.ipaddr(node_id) | ansible.netcommon.ipaddr('address') }}"
+monitor_address: "192.168.16.{{ node_id }}"
+radosgw_address: "192.168.16.{{ node_id }}"
 
 devices: "{{ ansible_local.testbed_ceph_devices }}"
 


### PR DESCRIPTION
Since we use older versions of Ansible in ceph-ansible and
partly in kolla-ansible it is currently not possible to use
the ipaddr module anymore.

The module can be used again if we use Ansible >=4.0.0
everywhere.

Signed-off-by: Christian Berendt <berendt@osism.tech>