### PR TITLE
Fix redis check

### DIFF
--- a/contrib/check_infrastructure_services.sh
+++ b/contrib/check_infrastructure_services.sh
@@ -29,7 +29,7 @@ echo
 echo "# Redis"
 echo
 
-/usr/lib/nagios/plugins/check_tcp -H 192.168.16.10 -p 6379 -A -E -s 'AUTH QHNA1SZRlOKzLADhUd5ZDgpHfQe6dNfr3bwEdY24\r\nPING\r\nINFO replication\r\nQUIT\r\n' -e 'PONG' -e 'role:master' -e 'slave0:ip=192.168.16.11,port=6379' -j
+/usr/lib/nagios/plugins/check_tcp -H 192.168.16.10 -p 6379 -A -E -s 'AUTH QHNA1SZRlOKzLADhUd5ZDgpHfQe6dNfr3bwEdY24\r\nPING\r\nINFO replication\r\nQUIT\r\n' -e 'PONG' -e 'role:master' -e 'slave0:ip=192.168.16.1' -e',port=6379' -j
 
 echo
 echo "# Ceph"


### PR DESCRIPTION
The first redis slave can be either of the two other nodes, split the
expected response pattern so that it matches both variants.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>