### PR TITLE
Use openstack.cloud tasks & FQCN tasks

### DIFF
--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -1,25 +1,27 @@
 ---
 - name: Prepare masquerading on the manager node
   hosts: testbed-managers
+  collections:
+    - ansible.builtin
 
   tasks:
     - name: Accpet FORWARD on the management interface (incoming)
       become: true
-      iptables:
+      ansible.builtin.iptables:
         chain: FORWARD
         in_interface: "{{ ansible_local.testbed_network_devices.management }}"
         jump: ACCEPT
 
     - name: Accept FORWARD on the management interface (outgoing)
       become: true
-      iptables:
+      ansible.builtin.iptables:
         chain: FORWARD
         out_interface: "{{ ansible_local.testbed_network_devices.management }}"
         jump: ACCEPT
 
     - name: Masquerade traffic on the management interface
       become: true
-      iptables:
+      ansible.builtin.iptables:
         table: nat
         chain: POSTROUTING
         out_interface: "{{ ansible_local.testbed_network_devices.management }}"
@@ -28,11 +30,13 @@
 - name: Create SCS flavors
   hosts: localhost
   connection: local
+  collections:
+    - openstack.cloud
 
   tasks:
     # vCPU:RAM ratio: 4:8
     - name: "Create SCS-4V:8 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-4V:8"
@@ -42,7 +46,7 @@
         ephemeral: 0
 
     - name: "Create SCS-4V:8:20 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-4V:8:20"
@@ -53,7 +57,7 @@
 
     # vCPU:RAM ratio: 2:8
     - name: "Create SCS-2V:8 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-2V:8"
@@ -63,7 +67,7 @@
         ephemeral: 0
 
     - name: "Create SCS-2V:8:20 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-2V:8:20"
@@ -74,7 +78,7 @@
 
     # vCPU:RAM ratio: 1:8
     - name: "Create SCS-1V:8 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-1V:8"
@@ -84,7 +88,7 @@
         ephemeral: 0
 
     - name: "Create SCS-1V:8:20 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-1V:8:20"
@@ -95,7 +99,7 @@
 
     # vCPU:RAM ratio: 2:4
     - name: "Create SCS-2V:4 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-2V:4"
@@ -105,7 +109,7 @@
         ephemeral: 0
 
     - name: "Create SCS-2V:4:10 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-2V:4:10"
@@ -116,7 +120,7 @@
 
     # vCPU:RAM ratio: 1:4
     - name: "Create SCS-1V:4 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-1V:4"
@@ -126,7 +130,7 @@
         ephemeral: 0
 
     - name: "Create SCS-1V:4:10 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-1V:4:10"
@@ -137,7 +141,7 @@
 
     # vCPU:RAM ratio: 1:2
     - name: "Create SCS-1V:2 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-1V:2"
@@ -147,7 +151,7 @@
         ephemeral: 0
 
     - name: "Create SCS-1V:2:5 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-1V:2:5"
@@ -158,7 +162,7 @@
 
     # vCPU:RAM ratio: 1:1
     - name: "Create SCS-1L:1 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-1L:1"
@@ -168,7 +172,7 @@
         ephemeral: 0
 
     - name: "Create SCS-1L:1:5 SCS flavor"
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "SCS-1L:1:5"
@@ -180,17 +184,20 @@
 - name: Bootstrap basic OpenStack services
   hosts: localhost
   connection: local
+  collections:
+    - ansible.builtin
+    - openstack.cloud
 
   tasks:
     - name: Create test project
-      os_project:
+      openstack.cloud.project:
         cloud: admin
         state: present
         name: test
         domain_id: default
 
     - name: Create test user
-      os_user:
+      openstack.cloud.identity_user:
         cloud: admin
         state: present
         name: test
@@ -202,13 +209,13 @@
 
     # NOTE: this role is required by octavia
     - name: Create load-balancer_member role
-      os_keystone_role:
+      openstack.cloud.identity_role:
         cloud: admin
         state: present
         name: load-balancer_member
 
     - name: Add member roles to user test
-      os_user_role:
+      openstack.cloud.role_assignment:
         cloud: admin
         state: present
         user: test
@@ -220,12 +227,12 @@
         - _member_
 
     - name: Download cirros image
-      get_url:
+      ansible.builtin.get_url:
         url: https://github.com/cirros-dev/cirros/releases/download/0.5.2/cirros-0.5.2-x86_64-disk.img
         dest: /tmp/cirros.img
 
     - name: Upload cirros image
-      os_image:
+      openstack.cloud.image:
         cloud: admin
         state: present
         name: cirros
@@ -240,20 +247,20 @@
 
     # NOTE: is_public from os_image is not working like expected
     - name: Make cirros image visible
-      command: openstack --os-cloud admin image set --public cirros  # noqa 301
+      ansible.builtin.command: openstack --os-cloud admin image set --public cirros  # noqa 301
 
     - name: Download ubuntu minimal 20.04 image
-      get_url:
+      ansible.builtin.get_url:
         url: http://cloud-images.ubuntu.com/minimal/releases/focal/release/ubuntu-20.04-minimal-cloudimg-amd64.img
         dest: /tmp/ubuntu.img
 
     - name: Get timestamp from the system
-      command: "date +%Y-%m-%d"
+      ansible.builtin.command: "date +%Y-%m-%d"
       register: date
       changed_when: false
 
     - name: Upload ubuntu minimal 20.04 image
-      os_image:
+      openstack.cloud.image:
         cloud: admin
         state: present
         name: "Ubuntu 20.04"
@@ -282,10 +289,10 @@
 
     # NOTE: is_public from os_image is not working like expected
     - name: Make ubuntu minimal 20.04 image visible
-      command: openstack --os-cloud admin image set --public 'Ubuntu 20.04'  # noqa 301
+      ansible.builtin.command: openstack --os-cloud admin image set --public 'Ubuntu 20.04'  # noqa 301
 
     - name: Create public network
-      os_network:
+      openstack.cloud.network:
         cloud: admin
         state: present
         name: public
@@ -295,7 +302,7 @@
         mtu: 1300  # NOTE: necessary because Geneve/VxLAN in Geneve/VxLAN
 
     - name: Create public subnet
-      os_subnet:
+      openstack.cloud.subnet:
         cloud: admin
         state: present
         name: subnet-public
@@ -307,14 +314,14 @@
         gateway_ip: 192.168.112.5
 
     - name: Create test network
-      os_network:
+      openstack.cloud.network:
         cloud: test
         state: present
         name: test
         mtu: 1300  # NOTE: necessary because Geneve/VxLAN in Geneve/VxLAN
 
     - name: Create test subnet
-      os_subnet:
+      openstack.cloud.subnet:
         cloud: test
         state: present
         name: subnet-test
@@ -322,7 +329,7 @@
         cidr: 192.168.200.0/24
 
     - name: Create test router
-      os_router:
+      openstack.cloud.router:
         cloud: test
         state: present
         name: router-test
@@ -331,13 +338,13 @@
           - subnet-test
 
     - name: Create ssh security group
-      os_security_group:
+      openstack.cloud.security_group:
         cloud: test
         state: present
         name: ssh
 
     - name: Add rule to ssh security group
-      os_security_group_rule:
+      openstack.cloud.security_group_rule:
         cloud: test
         state: present
         security_group: ssh
@@ -347,13 +354,13 @@
         remote_ip_prefix: 0.0.0.0/0
 
     - name: Create icmp security group
-      os_security_group:
+      openstack.cloud.security_group:
         cloud: test
         state: present
         name: icmp
 
     - name: Add rule to icmp security group
-      os_security_group_rule:
+      openstack.cloud.security_group_rule:
         cloud: test
         state: present
         security_group: icmp
@@ -361,14 +368,14 @@
         remote_ip_prefix: 0.0.0.0/0
 
     - name: Create test keypair
-      os_keypair:
+      openstack.cloud.keypair:
         cloud: test
         state: present
         name: test
         public_key_file: /opt/configuration/environments/openstack/id_rsa.test.pub
 
     - name: Create test instance
-      os_server:
+      openstack.cloud.server:
         cloud: test
         state: present
         name: test
@@ -382,14 +389,14 @@
           - ssh
 
     - name: Create test volume
-      os_volume:
+      openstack.cloud.volume:
         cloud: test
         state: present
         name: test
         size: 1
 
     - name: Attach test volume
-      os_server_volume:
+      openstack.cloud.server_volume:
         cloud: test
         state: present
         server: test

--- a/environments/openstack/playbook-bootstrap-ceph-rgw.yml
+++ b/environments/openstack/playbook-bootstrap-ceph-rgw.yml
@@ -2,10 +2,12 @@
 - name: Bootstrap ceph rgw
   hosts: localhost
   connection: local
+  collections:
+    - openstack.cloud
 
   tasks:
     - name: Create swift service account
-      os_user:
+      openstack.cloud.identity_user:
         cloud: admin
         state: present
         name: swift
@@ -15,7 +17,7 @@
       no_log: true
 
     - name: Add admin role to swift service account
-      os_user_role:
+      openstack.cloud.identity_role:
         cloud: admin
         state: present
         user: swift
@@ -23,7 +25,7 @@
         project: service
 
     - name: Create swift service
-      os_keystone_service:
+      openstack.cloud.catalog_service:
         cloud: admin
         state: present
         name: swift
@@ -31,7 +33,7 @@
         description: Openstack Object Storage
 
     - name: Create swift internal endpoint
-      os_keystone_endpoint:
+      openstack.cloud.endpoint:
         cloud: admin
         state: present
         service: swift
@@ -40,7 +42,7 @@
         region: RegionOne
 
     - name: Create swift public endpoint
-      os_keystone_endpoint:
+      openstack.cloud.endpoint:
         cloud: admin
         state: present
         service: swift

--- a/environments/openstack/playbook-bootstrap-magnum.yml
+++ b/environments/openstack/playbook-bootstrap-magnum.yml
@@ -2,15 +2,18 @@
 - name: Bootstrap magnum
   hosts: localhost
   connection: local
+  collections:
+    - ansible.builtin
+    - openstack.cloud
 
   tasks:
     - name: Download coreos image
-      get_url:
+      ansible.builtin.get_url:
         url: https://mirror.betacloud.io/fedora-coreos/fedora-coreos-31.20200407.3.0-openstack.x86_64.qcow2
         dest: /tmp/coreos.img
 
     - name: Upload coreos image
-      os_image:
+      openstack.cloud.image:
         cloud: admin
         state: present
         name: "Fedora CoreOS 31"
@@ -23,7 +26,7 @@
           os_distro: fedora-coreos
 
     - name: Get image information
-      os_image_info:
+      openstack.cloud.image_info:
         cloud: test
         image: "Fedora CoreOS 31"
       register: image
@@ -31,10 +34,10 @@
     # NOTE: is_public from os_image is not working like expected
 
     - name: Make coreos image visible
-      command: openstack --os-cloud admin image set --public 'Fedora CoreOS 31'  # noqa 301
+      ansible.builtin.command: openstack --os-cloud admin image set --public 'Fedora CoreOS 31'  # noqa 301
 
     - name: Create coreos flavor
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: 2C-2GB-10GB
@@ -47,13 +50,13 @@
       register: flavor
 
     - name: Get external network information
-      os_networks_info:
+      openstack.cloud.networks_info:
         cloud: test
         name: public
       register: network
 
     - name: Create cores magnum template
-      os_coe_cluster_template:
+      openstack.cloud.coe_cluster_template:
         name: "Fedora CoreOS 31 - Kubernetes"
         cloud: test
         state: present

--- a/environments/openstack/playbook-bootstrap-refstack.yml
+++ b/environments/openstack/playbook-bootstrap-refstack.yml
@@ -1,6 +1,10 @@
 ---
 - name: Bootstrap refstack
   hosts: localhost
+  collections:
+    - ansible.builtin
+    - community.general
+    - openstack.cloud
 
   vars:
     refstack_users:
@@ -12,7 +16,7 @@
 
   tasks:
     - name: Create refstack projects
-      os_project:
+      openstack.cloud.project:
         cloud: admin
         state: present
         name: "{{ item }}"
@@ -20,7 +24,7 @@
       loop: "{{ refstack_users }}"
 
     - name: Create refstack users
-      os_user:
+      openstack.cloud.identity_user:
         cloud: admin
         state: present
         name: "{{ item }}"
@@ -31,7 +35,7 @@
       no_log: true
 
     - name: Add admin role to required users
-      os_user_role:
+      openstack.cloud.identity_role:
         cloud: admin
         state: present
         user: "{{ item }}"
@@ -42,7 +46,7 @@
         - refstack-4
 
     - name: Add member roles to refstack users
-      os_user_role:
+      openstack.cloud.identity_role:
         cloud: admin
         state: present
         user: "{{ item.0 }}"
@@ -54,7 +58,7 @@
         - ['member', '_member_']
 
     - name: Create refstack keypairs
-      os_keypair:
+      openstack.cloud.keypair:
         cloud: "{{ item }}"
         state: present
         name: refstack
@@ -62,7 +66,7 @@
       loop: "{{ refstack_users }}"
 
     - name: Create test networks
-      os_network:
+      openstack.cloud.network:
         cloud: admin
         project: "{{ item }}"
         state: present
@@ -70,7 +74,7 @@
       loop: "{{ refstack_users }}"
 
     - name: Create test subnets
-      os_subnet:
+      openstack.cloud.subnet:
         cloud: admin
         project: "{{ item }}"
         state: present
@@ -82,7 +86,7 @@
         index_var: index
 
     - name: Create test router
-      os_router:
+      openstack.cloud.router:
         cloud: admin
         project: "{{ item }}"
         state: present
@@ -93,7 +97,7 @@
       loop: "{{ refstack_users }}"
 
     - name: Create tiny flavors
-      os_nova_flavor:
+      openstack.cloud.compute_flavor:
         cloud: admin
         state: present
         name: "{{ item }}"
@@ -109,17 +113,17 @@
       register: flavors
 
     # - name: Download image
-    #   get_url:
+    #   ansible.builtin.get_url:
     #     url: http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
     #     dest: /tmp/image.img
 
     - name: Download image
-      get_url:
+      ansible.builtin.get_url:
         url: https://github.com/cirros-dev/cirros/releases/download/0.5.2/cirros-0.5.2-x86_64-disk.img
         dest: /tmp/image.img
 
     - name: Upload images
-      os_image:
+      openstack.cloud.image:
         cloud: admin
         state: present
         name: "{{ item }}"
@@ -137,19 +141,19 @@
     # NOTE: is_public from os_image is not working like expected
 
     - name: Make images visible
-      command: "openstack --os-cloud admin image set --public {{ item }}"  # noqa 301
+      ansible.builtin.command: "openstack --os-cloud admin image set --public {{ item }}"  # noqa 301
       loop:
         - refstack-0
         - refstack-1
 
     - name: Get public network
-      os_networks_info:
+      openstack.cloud.networks_info:
         cloud: admin
         name: public
       register: public
 
     - name: Set image_ref in heat_plugin in tempest.conf
-      ini_file:
+      community.general.ini_file:
         path: /opt/configuration/contrib/refstack/tempest.conf
         section: heat_plugin
         option: image_ref
@@ -158,7 +162,7 @@
       delegate_to: testbed-manager
 
     - name: Set minimal_image_ref in heat_plugin in tempest.conf
-      ini_file:
+      community.general.ini_file:
         path: /opt/configuration/contrib/refstack/tempest.conf
         section: heat_plugin
         option: minimal_image_ref
@@ -167,7 +171,7 @@
       delegate_to: testbed-manager
 
     - name: Set image_ref in compute in tempest.conf
-      ini_file:
+      community.general.ini_file:
         path: /opt/configuration/contrib/refstack/tempest.conf
         section: compute
         option: image_ref
@@ -176,7 +180,7 @@
       delegate_to: testbed-manager
 
     - name: Set image_ref_alt in compute in tempest.conf
-      ini_file:
+      community.general.ini_file:
         path: /opt/configuration/contrib/refstack/tempest.conf
         section: compute
         option: image_ref_alt
@@ -185,7 +189,7 @@
       delegate_to: testbed-manager
 
     - name: Set flavor_ref in compute in tempest.conf
-      ini_file:
+      community.general.ini_file:
         path: /opt/configuration/contrib/refstack/tempest.conf
         section: compute
         option: flavor_ref
@@ -194,7 +198,7 @@
       delegate_to: testbed-manager
 
     - name: Set flavor_ref_alt in compute in tempest.conf
-      ini_file:
+      community.general.ini_file:
         path: /opt/configuration/contrib/refstack/tempest.conf
         section: compute
         option: flavor_ref_alt
@@ -203,7 +207,7 @@
       delegate_to: testbed-manager
 
     - name: Set public_network_id in network in tempest.conf
-      ini_file:
+      community.general.ini_file:
         path: /opt/configuration/contrib/refstack/tempest.conf
         section: network
         option: public_network_id
@@ -212,12 +216,12 @@
       delegate_to: testbed-manager
 
     - name: Check swift endpoint
-      command: openstack --os-cloud admin endpoint list --service swift  # noqa 301
+      ansible.builtin.command: openstack --os-cloud admin endpoint list --service swift  # noqa 301
       register: result
       delegate_to: testbed-manager
 
     - name: Set swift in tempest.conf
-      ini_file:
+      community.general.ini_file:
         path: /opt/configuration/contrib/refstack/tempest.conf
         section: service_available
         option: swift


### PR DESCRIPTION
- replaced all os_tasks with the corresponding openstack.cloud tasks.
- used for other tasks ansible.builtin and community.general tasks
- Make all collections available
- This close issues#1100

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
