### PR TITLE
terraform: DEBIAN_FRONTEND=noninteractive

### DIFF
--- a/terraform/files/manager.sh
+++ b/terraform/files/manager.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export DEBIAN_FRONTEND=noninteractive
+
 # NOTE: Because DNS queries don't always work directly at the beginning a
 #       retry for APT.
 echo "APT::Acquire::Retries \"3\";" > /etc/apt/apt.conf.d/80-retries


### PR DESCRIPTION
This will solve the following warning:

dpkg-preconfigure: unable to re-open stdin: No such file or directory

Closes #1074

Signed-off-by: Christian Berendt <berendt@osism.tech>