### PR TITLE
kolla: remove xtrabackup section from galera.cnf

### DIFF
--- a/environments/kolla/files/overlays/galera.cnf
+++ b/environments/kolla/files/overlays/galera.cnf
@@ -1,7 +1,3 @@
 [mysqld]
 userstat = 1
 expire_logs_days = 14
-
-[xtrabackup]
-password = {{ database_password }}
-user = root


### PR DESCRIPTION
This is a leftover from the past and is no longer needed today.

Signed-off-by: Christian Berendt <berendt@osism.tech>