### PR TITLE
Fix Grafana unified alerting

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -46,9 +46,6 @@ openstack_logging_debug: "True"
 # elasticsearch
 es_heap_size: "1g"
 
-# grafana
-grafana_enable_unified_alerting: "yes"
-
 # mariadb
 enable_mariabackup: "yes"
 

--- a/environments/kolla/files/overlays/grafana/grafana.ini
+++ b/environments/kolla/files/overlays/grafana/grafana.ini
@@ -1,0 +1,9 @@
+[alerting]
+enabled = false
+
+[unified_alerting]
+enabled = true
+
+[smtp]
+enable = true
+from_address = alerts@osism.testbed


### PR DESCRIPTION
Unified alerting has be enabled by config overlay file.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>