### PR TITLE
terraform: fixing deprecated warning

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,8 +3,8 @@ output "private_key" {
   sensitive = true
 }
 
-resource "local_file" "id_rsa" {
-  filename          = ".id_rsa.${var.cloud_provider}"
-  file_permission   = "0600"
-  sensitive_content = openstack_compute_keypair_v2.key.private_key
+resource "local_sensitive_file" "id_rsa" {
+  filename        = ".id_rsa.${var.cloud_provider}"
+  file_permission = "0600"
+  content         = openstack_compute_keypair_v2.key.private_key
 }


### PR DESCRIPTION
terraform: fixing deprecated warning
│
│   with local_file.id_rsa,
│   on outputs.tf line 9, in resource "local_file" "id_rsa":
│    9:   sensitive_content = openstack_compute_keypair_v2.key.private_key
│
│ Use the `local_sensitive_file` resource instead.

Signed-off-by: Mathias Fechner <fechner@osism.tech>