### PR TITLE
Fix deploy-identity

### DIFF
--- a/scripts/999-identity-services.sh
+++ b/scripts/999-identity-services.sh
@@ -4,15 +4,11 @@ export INTERACTIVE=false
 
 osism apply openstackclient
 osism apply keycloak
-osism apply openldap
 
-osism apply --environment custom openldap-umc-policies
-osism apply --environment custom umc-admin-ldap
 osism apply --environment custom keycloak-oidc-client-config
-osism apply --environment custom keycloak-ldap-federation-config
 
 osism apply common
-osism apply haproxy
+osism apply loadbalancer
 osism apply memcached
 osism apply mariadb
 osism apply rabbitmq


### PR DESCRIPTION
* in Xena loadbalancer must be used instead of haproxy
* The LDAP integration is currently not used in the testbed,
  so it can be removed for the moment and reactivated later

Closes #1143

Signed-off-by: Christian Berendt <berendt@osism.tech>