### PR TITLE
kolla: remove custom heat.conf

### DIFF
--- a/environments/kolla/files/overlays/heat.conf
+++ b/environments/kolla/files/overlays/heat.conf
@@ -1,2 +1,0 @@
-[clients_keystone]
-insecure = True


### PR DESCRIPTION
No longer needed since the self-signed internal CA can now
be cleanly integrated at this point.

Signed-off-by: Christian Berendt <berendt@osism.tech>