### PR TITLE
terraform: use hashicorp/local >= 2.2

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,8 @@ terraform {
 
   required_providers {
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
+      version = ">= 2.2"
     }
 
     null = {


### PR DESCRIPTION
The resource type local_sensitive_file is only available
from version 2.2.

Closes #1167

Signed-off-by: Christian Berendt <berendt@osism.tech>