### PR TITLE
Add auto-renovate for the requirements.txt in docs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,8 @@
 {
   "extends": [
-    "config:base"
+    "github>osism/renovate-config"
   ],
-  "commitBody": "Signed-off-by: Renovate Bot <bot@renovateapp.com>"
+  "pip_requierements": {
+    "fileMatch": ["docs/requirements.txt"]
+  }
 }


### PR DESCRIPTION
- Add renovate for the requirements.txt to fix the Sphinx-version issues.
- Partly osism/issue#155

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
