### PR TITLE
Drop old "_member_" role

### DIFF
--- a/environments/ceph/configuration.yml
+++ b/environments/ceph/configuration.yml
@@ -41,7 +41,7 @@ ceph_conf_overrides:
   "client.rgw.{{ hostvars[inventory_hostname]['ansible_hostname'] }}.rgw0":
     "rgw content length compat": "true"
     "rgw enable apis": "swift, s3, admin"
-    "rgw keystone accepted roles": "member, _member_, admin"
+    "rgw keystone accepted roles": "member, admin"
     "rgw keystone accepted admin roles": "admin"
     "rgw keystone admin domain": "default"
     "rgw keystone admin password": "hF6NWPG4rWTpK00oANEcRAiKbwbEcKFHHYYskar2"

--- a/environments/kolla/files/overlays/keystone/federation/oidc/attribute_maps/oidc_attribute_mappingId1.json
+++ b/environments/kolla/files/overlays/keystone/federation/oidc/attribute_maps/oidc_attribute_mappingId1.json
@@ -20,9 +20,6 @@
                                 "name": "member"
                             },
                             {
-                                "name": "_member_"
-                            },
-                            {
                                 "name": "load-balancer_member"
                             }
                         ]

--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -217,7 +217,6 @@
       loop:
         - load-balancer_member
         - member
-        - _member_
 
     - name: Download cirros image
       ansible.builtin.get_url:

--- a/environments/openstack/playbook-bootstrap-refstack.yml
+++ b/environments/openstack/playbook-bootstrap-refstack.yml
@@ -49,13 +49,10 @@
       openstack.cloud.identity_role:
         cloud: admin
         state: present
-        user: "{{ item.0 }}"
-        role: "{{ item.1 }}"
-        project: "{{ item.0 }}"
-      # loop: "{{ refstack_users|lookup('cartesian', ['member', '_member_']) }}"
-      with_cartesian:
-        - "{{ refstack_users }}"
-        - ['member', '_member_']
+        user: "{{ item }}"
+        role: member
+        project: "{{ item }}"
+      loop: "{{ refstack_users }}"
 
     - name: Create refstack keypairs
       openstack.cloud.keypair:


### PR DESCRIPTION
The `_member_` role is no longer being used anywhere, drop all
references to it.

Closes #1180

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>