### PR TITLE
testbed: Enable customer facing disk encryption in testbed

### DIFF
--- a/environments/kolla/files/overlays/cinder.conf
+++ b/environments/kolla/files/overlays/cinder.conf
@@ -1,0 +1,2 @@
+[key_manager]
+backend = barbican

--- a/environments/kolla/files/overlays/nova/nova-compute.conf
+++ b/environments/kolla/files/overlays/nova/nova-compute.conf
@@ -1,2 +1,5 @@
 [libvirt]
 virt_type = {{ nova_virt_type }}
+
+[key_manager]
+backend = barbican

--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -440,7 +440,7 @@
         size: 1
         volume_type: LUKS
 
-    - name: Attach test volume
+    - name: Attach lukstest volume
       openstack.cloud.server_volume:
         cloud: test
         state: present

--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -181,6 +181,23 @@
         disk: 5
         ephemeral: 0
 
+- name: Create Encrypted Volume Type
+  hosts: localhost
+  connection: local
+  collections:
+    - ansible.builtin
+    - openstack.cloud
+  vars:
+     os_luks_vt: "volume type create"
+     os_luks_pr: "--encryption-provider luks"
+     os_luks_ch: "--encryption-cipher aes-xts-plain64"
+     os_luks_ks: "--encryption-key-size 256"
+     os_luks_fe: "--encryption-control-location front-end"
+  tasks:
+    # NOTE: Volume type create not exist openstack.cloud
+    - name: Encrypt Volume type named Luks creating
+      ansible.builtin.command: "openstack --os-cloud admin {{ os_luks_vt }} {{ os_luks_pr }} {{ os_luks_ch }} {{ os_luks_ks }} {{ os_luks_fe }} LUKS" # noqa 301
+
 - name: Bootstrap basic OpenStack services
   hosts: localhost
   connection: local
@@ -414,6 +431,21 @@
         state: present
         server: test
         volume: test
+
+    - name: Create encrypted test volume
+      openstack.cloud.volume:
+        cloud: test
+        state: present
+        name: lukstest
+        size: 1
+        volume_type: LUKS
+
+    - name: Attach test volume
+      openstack.cloud.server_volume:
+        cloud: test
+        state: present
+        server: test
+        volume: lukstest
 
     - name: Get info of server test
       openstack.cloud.server_info:

--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -187,7 +187,7 @@
   tasks:
     # NOTE: volume type not available in the openstack.cloud collection
     - name: Encrypt Volume type named Luks creating
-      ansible.builtin.command: openstack --os-cloud admin volume type create --encryption-provider luks --encryption-cipher aes-xts-plain64 --encryption-key-size 256 --encryption-control-location front-end LUKS # noqa 301
+      ansible.builtin.command: openstack --os-cloud admin volume type create --encryption-provider luks --encryption-cipher aes-xts-plain64 --encryption-key-size 256 --encryption-control-location front-end LUKS  # noqa 301
 
 - name: Bootstrap basic OpenStack services
   hosts: localhost

--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -188,11 +188,11 @@
     - ansible.builtin
     - openstack.cloud
   vars:
-     os_luks_vt: "volume type create"
-     os_luks_pr: "--encryption-provider luks"
-     os_luks_ch: "--encryption-cipher aes-xts-plain64"
-     os_luks_ks: "--encryption-key-size 256"
-     os_luks_fe: "--encryption-control-location front-end"
+    os_luks_vt: "volume type create"
+    os_luks_pr: "--encryption-provider luks"
+    os_luks_ch: "--encryption-cipher aes-xts-plain64"
+    os_luks_ks: "--encryption-key-size 256"
+    os_luks_fe: "--encryption-control-location front-end"
   tasks:
     # NOTE: Volume type create not exist openstack.cloud
     - name: Encrypt Volume type named Luks creating

--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -183,20 +183,11 @@
 
 - name: Create Encrypted Volume Type
   hosts: localhost
-  connection: local
-  collections:
-    - ansible.builtin
-    - openstack.cloud
-  vars:
-    os_luks_vt: "volume type create"
-    os_luks_pr: "--encryption-provider luks"
-    os_luks_ch: "--encryption-cipher aes-xts-plain64"
-    os_luks_ks: "--encryption-key-size 256"
-    os_luks_fe: "--encryption-control-location front-end"
+
   tasks:
-    # NOTE: Volume type create not exist openstack.cloud
+    # NOTE: volume type not available in the openstack.cloud collection
     - name: Encrypt Volume type named Luks creating
-      ansible.builtin.command: "openstack --os-cloud admin {{ os_luks_vt }} {{ os_luks_pr }} {{ os_luks_ch }} {{ os_luks_ks }} {{ os_luks_fe }} LUKS" # noqa 301
+      ansible.builtin.command: openstack --os-cloud admin volume type create --encryption-provider luks --encryption-cipher aes-xts-plain64 --encryption-key-size 256 --encryption-control-location front-end LUKS # noqa 301
 
 - name: Bootstrap basic OpenStack services
   hosts: localhost


### PR DESCRIPTION
enable in cinder.conf  and nova-compute.conf key manager barbican
enable a creation tasks for cinder volume type luks

Signed-off-by: Mathias Fechner <fechner@osism.tech>