### PR TITLE
Fix wrong openstack.cloud ansible modules

### DIFF
--- a/environments/openstack/playbook-bootstrap-ceph-rgw.yml
+++ b/environments/openstack/playbook-bootstrap-ceph-rgw.yml
@@ -17,7 +17,7 @@
       no_log: true
 
     - name: Add admin role to swift service account
-      openstack.cloud.identity_role:
+      openstack.cloud.role_assignment:
         cloud: admin
         state: present
         user: swift

--- a/environments/openstack/playbook-bootstrap-refstack.yml
+++ b/environments/openstack/playbook-bootstrap-refstack.yml
@@ -35,7 +35,7 @@
       no_log: true
 
     - name: Add admin role to required users
-      openstack.cloud.identity_role:
+      openstack.cloud.role_assignment:
         cloud: admin
         state: present
         user: "{{ item }}"
@@ -46,7 +46,7 @@
         - refstack-4
 
     - name: Add member roles to refstack users
-      openstack.cloud.identity_role:
+      openstack.cloud.role_assignment:
         cloud: admin
         state: present
         user: "{{ item }}"


### PR DESCRIPTION
- Fix the wrong ansible module: openstack.cloud.identity_role to the right one: openstack.cloud.role_assignment

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
