### PR TITLE
Use xena release everywhere

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -267,7 +267,7 @@ flavor_manager            SCS-4V:8:50
 flavor_node               SCS-8V:32:50
 image                     Ubuntu 20.04
 network_availability_zone south-2
-openstack_version         wallaby
+openstack_version         xena
 public                    external
 volume_availability_zone  south-2
 volume_size_storage       10

--- a/scripts/009-openstack-services-baremetal.sh
+++ b/scripts/009-openstack-services-baremetal.sh
@@ -2,8 +2,8 @@
 
 export INTERACTIVE=false
 
-curl https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos8-stable-wallaby.kernel -o /opt/configuration/environments/kolla/files/overlays/ironic/ironic-agent.kernel
-curl https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos8-stable-wallaby.initramfs -o /opt/configuration/environments/kolla/files/overlays/ironic/ironic-agent.initramfs
+curl https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos8-stable-xena.kernel -o /opt/configuration/environments/kolla/files/overlays/ironic/ironic-agent.kernel
+curl https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos8-stable-xena.initramfs -o /opt/configuration/environments/kolla/files/overlays/ironic/ironic-agent.initramfs
 
 # NOTE: The docker-compose role is currently required for the
 #       virtualbmc service. Can be removed again when everything

--- a/scripts/set-openstack-version.sh
+++ b/scripts/set-openstack-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_VERSION=wallaby
-VERSION=${1:-wallaby}
+DEFAULT_VERSION=xena
+VERSION=${1:-xena}
 
 sed -i "s/openstack_version: ${DEFAULT_VERSION}/openstack_version: ${VERSION}/g" environments/manager/configuration.yml


### PR DESCRIPTION
Wallaby was still left in a few places. It should be Xena everywhere.

Related to #1206

Signed-off-by: Christian Berendt <berendt@osism.tech>