### PR TITLE
infrastructure: add nexus_traefik_host parameter

### DIFF
--- a/environments/infrastructure/configuration.yml
+++ b/environments/infrastructure/configuration.yml
@@ -51,7 +51,8 @@ netbox_plugins_extra:
 ##########################
 # nexus
 
-nexus_host: nexus.testbed.osism.xyz
+nexus_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface]['ipv4']['address'] }}"
+nexus_traefik_host: nexus.testbed.osism.xyz
 nexus_traefik: true
 
 ##########################


### PR DESCRIPTION
Necessary because Nexus has to listen internally on nexus_host for the
delivery of various repositories and this has to be an IP address.

Signed-off-by: Christian Berendt <berendt@osism.tech>