### PR TITLE
Remove ceph_share_directory

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -57,7 +57,6 @@ osism_serial:
 ##########################
 # ceph
 
-ceph_share_directory: /share
 ceph_cluster_fsid: 11111111-1111-1111-1111-111111111111
 
 ##########################


### PR DESCRIPTION
Now part of the defaults.

Signed-off-by: Christian Berendt <berendt@osism.tech>