### PR TITLE
kolla: remove nova_virt_type

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -94,7 +94,6 @@ nova_libvirt_extra_volumes:
 
 # nova
 nova_console: novnc
-nova_virt_type: kvm
 
 # octavia
 octavia_network_type: tenant

--- a/environments/kolla/files/overlays/nova/nova-compute.conf
+++ b/environments/kolla/files/overlays/nova/nova-compute.conf
@@ -1,5 +1,2 @@
-[libvirt]
-virt_type = {{ nova_virt_type }}
-
 [key_manager]
 backend = barbican


### PR DESCRIPTION
nova_compute_virt_type is now a default and is set to kvm by default.

Signed-off-by: Christian Berendt <berendt@osism.tech>