### PR TITLE
Add neutron_ssh_key secret to kolla environment

### DIFF
--- a/environments/kolla/secrets.yml
+++ b/environments/kolla/secrets.yml
@@ -400,6 +400,9 @@ murano_keystone_password: UOExa9G5lqRyTFquCYXMWgToLNcYzdpWa6vFri1A
 neutron_database_password: r1P3wCAuk8Y8fFTIuAub1hJEksslx0kCnbOzpCul
 neutron_keystone_password: M2rHnNvseRVP7tfoO59sQfBjFelY7Xl9R9q87Mdo
 nova_api_database_password: Yt3SHjyHbsINSt1Y2S2xvmIuId2oPUT5FXa8QZTK
+neutron_ssh_key:
+  private_key:
+  public_key:
 nova_database_password: vRAt2MSi0uqCCUaSVfO4i9keuNTUp94E8xp4kpJB
 nova_keystone_password: ELiH70zuu3cuhzqZnsZDFzYEOVRVKd5RzqLjgEin
 nova_ssh_key:


### PR DESCRIPTION
This variable was added to kolla in the yoga cycle[0]. Since we don't
actually use this anywhere in the testbed, just add an empty key in
order to make ansible happy.

[0] https://review.opendev.org/c/openstack/kolla-ansible/+/835200
Closes: #1299
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>