### PR TITLE
Set bash scripts to exit on error

### DIFF
--- a/scripts/001-helper-services.sh
+++ b/scripts/001-helper-services.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export INTERACTIVE=false
 

--- a/scripts/002-infrastructure-services-basic.sh
+++ b/scripts/002-infrastructure-services-basic.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export INTERACTIVE=false
 

--- a/scripts/003-ceph-services.sh
+++ b/scripts/003-ceph-services.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export INTERACTIVE=false
 

--- a/scripts/004-openstack-services-basic.sh
+++ b/scripts/004-openstack-services-basic.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export INTERACTIVE=false
 

--- a/scripts/005-monitoring-services.sh
+++ b/scripts/005-monitoring-services.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export INTERACTIVE=false
 

--- a/scripts/006-infrastructure-services-extended.sh
+++ b/scripts/006-infrastructure-services-extended.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export INTERACTIVE=false
 

--- a/scripts/007-openstack-services-extended.sh
+++ b/scripts/007-openstack-services-extended.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export INTERACTIVE=false
 

--- a/scripts/008-openstack-services-additional.sh
+++ b/scripts/008-openstack-services-additional.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export INTERACTIVE=false
 

--- a/scripts/009-openstack-services-baremetal.sh
+++ b/scripts/009-openstack-services-baremetal.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export INTERACTIVE=false
 

--- a/scripts/100-refstack.sh
+++ b/scripts/100-refstack.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 pushd /opt/configuration/contrib/refstack
 

--- a/scripts/999-identity-services.sh
+++ b/scripts/999-identity-services.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 export INTERACTIVE=false
 


### PR DESCRIPTION
With the change in [0], the "osism apply" commands will return an error
code if the execution exits with a failure. Make sure that our
deployment scripts actually stop in this case in order to make debugging
easier.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>