### PR TITLE
Fix missing variable in keystone deployment

### DIFF
--- a/environments/kolla/files/overlays/keystone/wsgi-keystone.conf
+++ b/environments/kolla/files/overlays/keystone/wsgi-keystone.conf
@@ -8,11 +8,7 @@ LoadModule ssl_module /usr/lib/apache2/modules/mod_ssl.so
 {% endif %}
 {% endif %}
 Listen {{ api_interface_address | put_address_in_context('url') }}:{{ keystone_public_listen_port }}
-{% if kolla_action == 'upgrade' %}
-# NOTE(yoctozepto): Admin port settings are kept only for upgrade compatibility.
-# TODO(yoctozepto): Remove after Zed.
 Listen {{ api_interface_address | put_address_in_context('url') }}:{{ keystone_admin_listen_port }}
-{% endif %}
 
 ServerSignature Off
 ServerTokens Prod
@@ -39,7 +35,7 @@ LogLevel info
 
 
 <VirtualHost *:{{ keystone_public_listen_port }}>
-    WSGIDaemonProcess keystone-public processes={{ keystone_api_workers }} threads=1 user=keystone group=keystone display-name=keystone-public
+    WSGIDaemonProcess keystone-public processes={{ openstack_service_workers }} threads=1 user=keystone group=keystone display-name=keystone-public
     WSGIProcessGroup keystone-public
     WSGIScriptAlias / {{ binary_path }}/keystone-wsgi-public
     WSGIApplicationGroup %{GLOBAL}
@@ -72,7 +68,7 @@ LogLevel info
 {% endif %}
     OIDCCryptoPassphrase {{ keystone_federation_openid_crypto_password }}
     OIDCRedirectURI {{ keystone_public_url }}/redirect_uri
-{% if enable_memcached | bool and keystone_oidc_enable_memcached | bool %}
+{% if enable_memcached | bool %}
     OIDCCacheType memcache
     OIDCMemCacheServers "{% for host in groups['memcached'] %}{{ 'api' | kolla_address(host) | put_address_in_context('memcache') }}:{{ memcached_port }}{% if not loop.last %} {% endif %}{% endfor %}"
 {% endif %}
@@ -117,11 +113,8 @@ LogLevel info
 {% endif %}
 </VirtualHost>
 
-{% if kolla_action == 'upgrade' %}
-# NOTE(yoctozepto): Admin port settings are kept only for upgrade compatibility.
-# TODO(yoctozepto): Remove after Zed.
 <VirtualHost *:{{ keystone_admin_listen_port }}>
-    WSGIDaemonProcess keystone-admin processes={{ keystone_api_workers }} threads=1 user=keystone group=keystone display-name=keystone-admin
+    WSGIDaemonProcess keystone-admin processes={{ openstack_service_workers }} threads=1 user=keystone group=keystone display-name=keystone-admin
     WSGIProcessGroup keystone-admin
     WSGIScriptAlias / {{ binary_path }}/keystone-wsgi-admin
     WSGIApplicationGroup %{GLOBAL}
@@ -139,4 +132,3 @@ LogLevel info
     SSLCertificateKeyFile /etc/keystone/certs/keystone-key.pem
 {% endif %}
 </VirtualHost>
-{% endif %}


### PR DESCRIPTION
The override template that was introduced in #1097 uses a kolla variable
that was added only in Zed. Add the variable definition temporarily so
that we don't need to make the template version dependent.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>