### PR TITLE
playbooks: use ansible_user_dir instead of /home/ubuntu

### DIFF
--- a/ansible/manager-part-0.yml
+++ b/ansible/manager-part-0.yml
@@ -1,9 +1,8 @@
 ---
 - name: set up the manager part 0
   hosts: testbed-manager.testbed.osism.xyz
-  gather_facts: false
   vars:
-    repo_path: /home/ubuntu/src/github.com
+    repo_path: "{{ ansible_user_dir }}/src/github.com"
   tasks:
     - name: Update APT cache and run dist-upgrade
       become: true

--- a/ansible/manager-part-1.yml
+++ b/ansible/manager-part-1.yml
@@ -1,11 +1,10 @@
 ---
 - name: set up the manager part 1
   hosts: testbed-manager.testbed.osism.xyz
-  gather_facts: false
   vars:
     operator_user: dragon
     ansible_ssh_user: dragon
-    repo_path: /home/ubuntu/src/github.com
+    repo_path: "{{ ansible_user_dir }}/src/github.com"
   tasks:
     - name: Copy SSH public key
       ansible.builtin.copy:


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>