### PR TITLE
Set higher timeout for loadbalancer creation

### DIFF
--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -462,6 +462,7 @@
         vip_network: test
         auto_public_ip: true
         public_network: public
+        timeout: 600
         listeners:
           - name: listener_test_22
             protocol: TCP


### PR DESCRIPTION
Depending on the performance of the underlying cloud, the creation of a
loadbalancer may take a long time. Increase the timeout from the default
of 3 minutes to 10 minutes.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>