### PR TITLE
Change from Python3-crypto to Python3-cryptography

### DIFF
--- a/ansible/manager-part-0.yml
+++ b/ansible/manager-part-0.yml
@@ -23,7 +23,7 @@
         apt-get install --yes \
           git-lfs \
           python3-argcomplete \
-          python3-crypto \
+          python3-cryptography \
           python3-dnspython \
           python3-jmespath \
           python3-kerberos \


### PR DESCRIPTION
In preparation to Ubuntu 22.04 we need to change the python3-crypto package.
Python3-cryptography worked in a Testbed Testdeployment as well as Python3-crypto.
Closes osism/testbed#1291

Signed-off-by: Ramona Beermann <rautenberg@osism.tech>
