### PR TITLE
terraform: allow use of ephemeral storage

### DIFF
--- a/environments/custom/files/testbed_ceph_devices.fact
+++ b/environments/custom/files/testbed_ceph_devices.fact
@@ -30,4 +30,8 @@ else:
 
 devices = result.stdout.strip().split("\n")
 
-print(json.dumps([f"/dev/{x}" for x in devices[:-1]]))
+if len(devices) > 1:
+    print(json.dumps([f"/dev/{x}" for x in devices[:-1]]))
+else:
+    # NOTE: If there is only one device for Ceph, this is always used.
+    print(json.dumps([f"/dev/{x}" for x in devices]))

--- a/scripts/check/100-ceph-services.sh
+++ b/scripts/check/100-ceph-services.sh
@@ -15,3 +15,27 @@ echo "# Ceph versions"
 echo
 
 ceph versions
+
+echo
+echo "# Ceph OSD tree"
+echo
+
+ceph osd df tree
+
+echo
+echo "# Ceph monitor status"
+echo
+
+ceph mon stat
+
+echo
+echo "# Ceph quorum status"
+echo
+
+< /dev/null ceph quorum_status | jq
+
+echo
+echo "# Ceph free space status"
+echo
+
+ceph df

--- a/terraform/customisations/default_custom.tf
+++ b/terraform/customisations/default_custom.tf
@@ -22,6 +22,8 @@ resource "openstack_compute_instance_v2" "node_server" {
 #cloud-config
 network:
    config: disabled
+mounts:
+  - [ ephemeral0, null ]
 package_update: true
 package_upgrade: true
 runcmd:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,6 +13,7 @@ terraform {
 
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = ">= 1.48.0"
     }
   }
 }

--- a/terraform/overrides/nodes_use_ephemeral_storage_override.tf
+++ b/terraform/overrides/nodes_use_ephemeral_storage_override.tf
@@ -1,0 +1,28 @@
+resource "openstack_compute_instance_v2" "node_server" {
+  block_device {
+    boot_index            = 0
+    destination_type      = "local"
+    source_type           = "image"
+    uuid                  = data.openstack_images_image_v2.image_node.id
+  }
+
+  block_device {
+    boot_index            = -1
+    destination_type      = "local"
+    source_type           = "blank"
+    volume_size           = var.volume_size_storage
+  }
+
+  # NOTE: At the moment by default only 3 local block devices are possible.
+  #
+  #       Block Device Mapping is Invalid: You specified more local devices than the limit allows
+  #
+  #       nova.conf: max_local_block_devices = 3
+
+  block_device {
+     boot_index            = -1
+     destination_type      = "local"
+     source_type           = "blank"
+     volume_size           = var.volume_size_storage
+  }
+}


### PR DESCRIPTION
Enables the use of the testbed on environments where Cinder is not usable or Cinder should not be used.

Signed-off-by: Christian Berendt <berendt@osism.tech>