### PR TITLE
terraform: do not attach volumes @ otc

### DIFF
--- a/terraform/environments/otc.tfvars
+++ b/terraform/environments/otc.tfvars
@@ -15,3 +15,4 @@ volume_size_storage       = "10"
 public                    = "admin_external_net"
 enable_dhcp               = "true"
 dns_nameservers           = ["100.125.4.25", "9.9.9.9"]
+number_of_volumes         = "0"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,7 +12,7 @@ terraform {
     }
 
     openstack = {
-      source = "terraform-provider-openstack/openstack"
+      source  = "terraform-provider-openstack/openstack"
       version = ">= 1.48.0"
     }
   }


### PR DESCRIPTION
The d-flavors have enough block devices out of the box.

Also fixes a small syntax thing.

Signed-off-by: Christian Berendt <berendt@osism.tech>