### PR TITLE
ansible: syntax issue

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -27,7 +27,7 @@
 
     - name: Set manager_host address
       ansible.builtin.set_fact:
-        manager_host: "{{ manager_address.stdout.split('=')[1] }}"
+        manager_host: "{{ manager_address.stdout | split('=') | last }}"
 
     - name: Update ansible collections
       ansible.builtin.shell:


### PR DESCRIPTION
new version of ansible/jina won't accept stdout.split

ansible [core 2.12.5]
python version = 3.9.14 (main, Sep  6 2022, 23:16:16) [Clang 13.1.6 (clang-1316.0.21.2.5)] jinja version = 3.1.2

Signed-off-by: Mathias Fechner <fechner@osism.tech>