### PR TITLE
Openstack cli examples

### DIFF
--- a/contrib/openstack-cli/README.md
+++ b/contrib/openstack-cli/README.md
@@ -8,7 +8,9 @@ ref:
 
 ### testbed SSL CA
 
-> :note: place the testbd SSL CA in ~/.config/openstack or adjust the files accordingly
+> **Note**
+> place the testbd SSL CA in ~/.config/openstack or adjust the files
+> accordingly
 
 ```bash
 mkdir -p ~/.config/openstack
@@ -18,12 +20,14 @@ wget https://github.com/osism/testbed/raw/main/environments/kolla/certificates/c
 
 ### clouds-public.yml, clouds.yaml + secure.yaml
 
-> :note: this also works if clouds-public.yml, clouds.yaml + secure.yaml
-are place in your current working directory if you don't want to place
-them in ~/.config/openstack.
+> **Note**
+> this also works if clouds-public.yml, clouds.yaml + secure.yaml
+> are place in your current working directory if you don't want to place
+> them in ~/.config/openstack.
 
-> :warning: **this overwrites your local openstack cli config, use with
-caution or adjust accordingly**
+> **Warning**
+> **this overwrites your local openstack cli config, use with caution
+> or adjust accordingly**
 
 ```bash
 wget -O clouds-public.yaml https://github.com/osism/testbed/raw/main/contrib/openstack-cli/clouds-public.yaml

--- a/contrib/openstack-cli/README.md
+++ b/contrib/openstack-cli/README.md
@@ -1,0 +1,33 @@
+# testbed openstack-cli examples outside the testbed-manager
+
+ref:
+*  [preparations.html#tls-certificates-and-hostnames](https://docs.osism.tech/testbed/preparations.html#tls-certificates-and-hostnames)
+*  [authentication.html#authentication-with-openid-connect](https://docs.osism.tech/testbed/authentication.html#authentication-with-openid-connect)
+
+## Usage:
+
+### testbed SSL CA
+
+> :note: place the testbd SSL CA in ~/.config/openstack or adjust the files accordingly
+
+```bash
+mkdir -p ~/.config/openstack
+cd ~/.config/openstack
+wget https://github.com/osism/testbed/raw/main/environments/kolla/certificates/ca/testbed.crt
+```
+
+### clouds-public.yml, clouds.yaml + secure.yaml
+
+> :note: this also works if clouds-public.yml, clouds.yaml + secure.yaml
+are place in your current working directory if you don't want to place
+them in ~/.config/openstack.
+
+> :warning: **this overwrites your local openstack cli config, use with
+caution or adjust accordingly**
+
+```bash
+wget -O clouds-public.yaml https://github.com/osism/testbed/raw/main/contrib/openstack-cli/clouds-public.yaml
+wget -O clouds.yaml https://github.com/osism/testbed/raw/main/contrib/openstack-cli/clouds.yaml.example
+wget -O secure.yaml https://github.com/osism/testbed/raw/main/contrib/openstack-cli/secure.yaml.example
+```
+

--- a/contrib/openstack-cli/clouds-public.yaml
+++ b/contrib/openstack-cli/clouds-public.yaml
@@ -1,0 +1,20 @@
+public-clouds:
+  testbed:
+    cacert: ~/.config/openstack/testbed.crt
+    auth:
+      auth_url: https://api.testbed.osism.xyz:5000
+    interface: 'public'
+    identity_api_version: 3
+  testbed-keycloak:
+    cacert: ~/.config/openstack/testbed.crt
+    auth:
+      auth_url: https://api.testbed.osism.xyz:5000
+      discovery_endpoint: https://keycloak.testbed.osism.xyz/auth/realms/osism/.well-known/openid-configuration
+      protocol: openid
+      client_id: keystone
+      client_secret: 0056b89c-030f-486b-a6ad-f0fa398fa4ad
+    interface: 'public'
+    identity_api_version: 3
+    auth_type: v3oidcpassword
+    identity_provider: keycloak
+

--- a/contrib/openstack-cli/clouds.yaml.example
+++ b/contrib/openstack-cli/clouds.yaml.example
@@ -1,0 +1,29 @@
+---
+# This is a clouds.yaml file, which can be used by OpenStack tools as a source
+# of configuration on how to connect to a cloud. If this is your only cloud,
+# just put this file in ~/.config/openstack/clouds.yaml and tools like
+# python-openstackclient will just work with no further config. (You will need
+# to add your password to the auth section)
+# If you have more than one cloud account, add the cloud entry to the clouds
+# section of your existing file and you can refer to them by name with
+# OS_CLOUD=openstack or --os-cloud=openstack
+clouds:
+  testbed-admin:
+    profile: testbed
+    auth:
+      username: admin
+      project_name: admin
+      project_domain_name: default
+      user_domain_name: default
+  testbed-test:
+    profile: testbed
+    auth:
+      username: test
+      project_name: test
+      project_domain_name: default
+      user_domain_name: default
+  testbed-alice:
+    profile: testbed-keycloak
+    auth:
+      username: alice
+      project_name: test

--- a/contrib/openstack-cli/secure.yaml.example
+++ b/contrib/openstack-cli/secure.yaml.example
@@ -1,0 +1,11 @@
+---
+clouds:
+  testbed-admin:
+    auth:
+      password: password
+  testbed-test:
+    auth:
+      password: test
+  testbed-alice:
+    auth:
+      password: password


### PR DESCRIPTION
just some helpful pointers if someone wants to use the openstack cli outside of the testbed manager in combination with the wireguard VPN