### PR TITLE
Use ansible.posix.synchronize instead of ansible.builtin.synchronize

### DIFF
--- a/ansible/manager-part-0.yml
+++ b/ansible/manager-part-0.yml
@@ -64,7 +64,7 @@
         - osism/ansible-collection-services
 
     - name: Copy sources
-      ansible.builtin.synchronize:
+      ansible.posix.synchronize:
         src: "{{ repo_path }}/{{ item }}"
         delete: true
         dest: "/opt/src/{{ item }}"

--- a/ansible/manager-part-1.yml
+++ b/ansible/manager-part-1.yml
@@ -36,7 +36,7 @@
     - name: Copy testbed repo
       become: true
       become_user: dragon
-      ansible.builtin.synchronize:
+      ansible.posix.synchronize:
         src: "{{ repo_path }}/osism/testbed/"
         delete: true
         dest: /opt/configuration


### PR DESCRIPTION
ansible.posix.synchronize is now the common way in ansible
https://docs.ansible.com/ansible/latest/collections/ansible/posix/synchronize_module.html#

Signed-off-by: Mathias Fechner <fechner@osism.tech>