### PR TITLE
CI: Add cloud cleanup in pre phase

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -27,6 +27,7 @@
       nodes:
         - name: orchestrator
           label: testbed-orchestrator
+    pre-run: playbooks/pre.yml
     run: playbooks/deploy.yml
     post-run: playbooks/post.yml
     required-projects:

--- a/playbooks/pre.yml
+++ b/playbooks/pre.yml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+
+  vars:
+    cloud_env: ci
+
+  tasks:
+    - name: Clean the cloud environment
+      ansible.builtin.shell:
+        cmd: |
+          echo y | ~/venv/bin/openstack --os-cloud {{ cloud_env }} project cleanup --auth-project
+          ~/venv/bin/openstack --os-cloud {{ cloud_env }} port list -f value -c id | xargs -l1 ~/venv/bin/openstack --os-cloud {{ cloud_env }} port delete
+          ~/venv/bin/openstack --os-cloud {{ cloud_env }} router remove subnet testbed subnet-testbed-management
+          ~/venv/bin/openstack --os-cloud {{ cloud_env }} router delete testbed
+          echo y | ~/venv/bin/openstack --os-cloud {{ cloud_env }} project cleanup --auth-project
+          ~/venv/bin/openstack --os-cloud {{ cloud_env }} keypair delete testbed
+      failed_when: false


### PR DESCRIPTION
Sometimes the post cleanup doesn't get executed properly. This can happen for multiple reasons, cloud instability, terraform state inconsistency, job aborted.

Add a new task in the pre-phase of a new deployment that makes sure all possible remainders of a previous run are cleaned up.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>