### PR TITLE
fixup! Mark subject alternative name extension as critical (#1394)

### DIFF
--- a/contrib/ownca/create_ca.yml
+++ b/contrib/ownca/create_ca.yml
@@ -18,7 +18,6 @@
         privatekey_passphrase: "{{ secret_ca_passphrase }}"
         common_name: OSISM Testbed CA
         use_common_name_for_san: false  # since we do not specify SANs, don't use CN as a SAN
-        subject_alt_name_critical: true
         basic_constraints:
           - 'CA:TRUE'
         basic_constraints_critical: true

--- a/contrib/ownca/create_wildcard.yml
+++ b/contrib/ownca/create_wildcard.yml
@@ -16,6 +16,7 @@
         privatekey_path: testbed-certificate.key
         subject_alt_name:
           - "DNS:*.testbed.osism.xyz"
+        subject_alt_name_critical: true
       run_once: true
       register: csr
 


### PR DESCRIPTION
It's the wildcard cert that needs the SAN marked "critical", not the CA cert.