### PR TITLE
ansible-lint: only warn about experimental rules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -17,3 +17,5 @@ skip_list:
   - fqcn-builtins
   - yaml
   - name[template]
+warn_list:
+  - experimental  # all rules tagged as experimental


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>