### PR TITLE
Bump timeout for upgrade job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -28,7 +28,7 @@
     run: playbooks/upgrade.yml
     # NOTE(frickler): Default zuul maximum timeout is 3h, this needs to
     # be explictly bumped in the tenant configuration
-    timeout: 14400
+    timeout: 16200
 
 - job:
     name: testbed-deploy-cleura


### PR DESCRIPTION
The testbed-upgrade job hit the 4h limit quite often. Bump the timeout to 4:30 h in order to give it a chance to finish successfully.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>