### PR TITLE
kolla: remove novncproxy_base_url

### DIFF
--- a/environments/kolla/files/overlays/nova.conf
+++ b/environments/kolla/files/overlays/nova.conf
@@ -1,2 +1,0 @@
-[vnc]
-novncproxy_base_url = http://192.168.16.254:6080/vnc_auto.html


### PR DESCRIPTION
The default value in the nova.conf template should be good enough.

Signed-off-by: Christian Berendt <berendt@osism.tech>