### PR TITLE
Use the OpenStack Image Manager to manage payload images

### DIFF
--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -205,8 +205,6 @@
 
   vars:
     openstack_version: yoga
-    url_ubuntu_image: https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img
-    url_cirros_image: https://github.com/cirros-dev/cirros/releases/download/0.5.2/cirros-0.5.2-x86_64-disk.img
 
   tasks:
     - name: Create test project
@@ -237,67 +235,6 @@
       loop:
         - load-balancer_member
         - member
-
-    - name: Download cirros image
-      ansible.builtin.get_url:
-        url: "{{ url_cirros_image }}"
-        dest: /tmp/cirros.img
-        mode: 0644
-
-    - name: Upload cirros image
-      openstack.cloud.image:
-        cloud: admin
-        state: present
-        name: cirros
-        is_public: true
-        container_format: bare
-        disk_format: qcow2
-        filename: /tmp/cirros.img
-        min_disk: 1
-        properties:
-          cpu_arch: x86_64
-          distro: ubuntu
-          hw_rng_model: virtio
-
-    - name: Download ubuntu minimal 22.04 image
-      ansible.builtin.get_url:
-        url: "{{ url_ubuntu_image }}"
-        dest: /tmp/ubuntu.img
-        mode: 0644
-
-    - name: Get timestamp from the system
-      ansible.builtin.command: "date +%Y-%m-%d"
-      register: date
-      changed_when: false
-
-    - name: Upload ubuntu minimal 22.04 image
-      openstack.cloud.image:
-        cloud: admin
-        state: present
-        name: "Ubuntu 22.04"
-        is_public: true
-        container_format: bare
-        disk_format: qcow2
-        filename: /tmp/ubuntu.img
-        min_disk: 3
-        min_ram: 512
-        properties:
-          architecture: x86_64
-          cpu_arch: x86_64
-          distro: ubuntu
-          hw_disk_bus: scsi
-          hw_rng_model: virtio
-          hw_scsi_model: virtio-scsi
-          hypervisor_type: kvm
-          # NOTE: The upload date is taken at this point. The Ubuntu upstream images are rotated and not archived.
-          image_build_date: "{{ date.stdout }}"
-          image_description: https://launchpad.net/cloud-images
-          image_original_user: ubuntu
-          image_source: "{{ url_ubuntu_image }}"
-          os_distro: ubuntu
-          os_version: "22.04"
-          replace_frequency: never
-          uuid_validity: forever
 
     - name: Download amphora image
       ansible.builtin.get_url:
@@ -409,7 +346,7 @@
         cloud: test
         state: present
         name: test
-        image: cirros
+        image: "Cirros 0.6.0"
         flavor: "SCS-1L:1:5"
         network: test
         delete_fip: true

--- a/scripts/deploy/300-openstack-services-basic.sh
+++ b/scripts/deploy/300-openstack-services-basic.sh
@@ -19,6 +19,9 @@ task_ids+=" "$(osism apply --no-wait --format script octavia 2>&1)
 
 osism wait --output --format script --delay 2 $task_ids
 
+osism manage images --cloud admin --filter Cirros
+osism manage images --cloud admin --name "Ubuntu 22.04 Minimal"
+
 osism apply --environment openstack bootstrap-basic -e openstack_version=$OPENSTACK_VERSION
 osism apply --environment openstack bootstrap-ceph-rgw
 


### PR DESCRIPTION
The image for Octavia will not be managed with the OpenStack Image Manager as this will be managed later within a playbook for Octavia itself.

Signed-off-by: Christian Berendt <berendt@osism.tech>