### PR TITLE
Fix netbox plugin list

### DIFF
--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -54,6 +54,10 @@ netbox_enable: true
 netbox_host: "netbox.testbed.osism.xyz"
 netbox_api_url: "https://{{ netbox_host }}"
 
+# TODO: drop again once role is fixed
+netbox_plugins:
+  - netbox_plugin_osism
+
 ##########################
 # configuration
 


### PR DESCRIPTION
The default plugin list isn't compatible with the old netbox version that is being used in the testbed, so we need to override it for now.

Closes: #1434

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>