### PR TITLE
Use images from quay.io for stable releases

### DIFF
--- a/scripts/deploy/000-manager-service.sh
+++ b/scripts/deploy/000-manager-service.sh
@@ -7,13 +7,18 @@ export INTERACTIVE=false
 
 /opt/configuration/scripts/set-manager-version.sh $MANAGER_VERSION
 
-# NOTE: For a stable release, the versions of Ceph and OpenStack to use
-#       are set by the version of the stable release (set via the
-#       manager_version parameter) and not by release names.
+# For a stable release, the versions of Ceph and OpenStack to use
+# are set by the version of the stable release (set via the
+# manager_version parameter) and not by release names.
 
 if [[ $MANAGER_VERSION == "latest" ]]; then
     /opt/configuration/scripts/set-ceph-version.sh $CEPH_VERSION
     /opt/configuration/scripts/set-openstack-version.sh $OPENSTACK_VERSION
+else
+    # For stable releases, we use the images from quay.io and not
+    # from harbor.services.osism.tech.
+
+    sed -i "s/docker_registry_ansible: .*/docker_registry_ansible: quay.io/g" /opt/configuration/environments/manager/configuration.yml
 fi
 
 wait_for_container_healthy() {
@@ -34,10 +39,10 @@ ansible-playbook -i testbed-manager.testbed.osism.xyz, /opt/configuration/ansibl
 
 cp /home/dragon/.ssh/id_rsa.pub /opt/ansible/secrets/id_rsa.operator.pub
 
-# NOTE(berendt): wait for ara-server service
+# wait for ara-server service
 wait_for_container_healthy 60 manager-ara-server-1
 
-# NOTE(berendt): wait for netbox service
+# wait for netbox service
 wait_for_container_healthy 60 netbox-netbox-1
 
 osism netbox import


### PR DESCRIPTION
The stable release images are located in a subdirectory on harbor.services.osism.tech. In the case of a stable release, it is easier to take the images from quay.io than to adapt all paths to the images.

Closes osism/testbed#1455

Signed-off-by: Christian Berendt <berendt@osism.tech>