### PR TITLE
Use images from quay.io for stable releases (pt. 2)

### DIFF
--- a/scripts/deploy/000-manager-service.sh
+++ b/scripts/deploy/000-manager-service.sh
@@ -19,6 +19,8 @@ else
     # from harbor.services.osism.tech.
 
     sed -i "s/docker_registry_ansible: .*/docker_registry_ansible: quay.io/g" /opt/configuration/environments/manager/configuration.yml
+    sed -i "s/ceph_docker_registry: .*/ceph_docker_registry: quay.io/g" /opt/configuration/environments/ceph/configuration.yml
+    sed -i "s/docker_registry_kolla: .*/docker_registry_kolla: quay.io/g" /opt/configuration/environments/kolla/configuration.yml
 fi
 
 wait_for_container_healthy() {


### PR DESCRIPTION
The stable release images are located in a subdirectory on harbor.services.osism.tech. In the case of a stable release, it is easier to take the images from quay.io than to adapt all paths to the images.

Part of osism/testbed#1455

Signed-off-by: Christian Berendt <berendt@osism.tech>