### PR TITLE
Revert "Use new --action argument to pull kolla images (#1447)"

### DIFF
--- a/scripts/000-pull-images.sh
+++ b/scripts/000-pull-images.sh
@@ -28,5 +28,5 @@ redis
 )
 
 for kolla_service in ${kolla_services[*]}; do
-    osism apply -a pull --no-wait $kolla_service
+    osism apply --no-wait $kolla_service -e kolla_action=pull
 done


### PR DESCRIPTION
This reverts commit b740f6b267bf824d002aa5de85b2db481d8deb59.

Does not work with older stable versions of the OSISM cli. Keep the old way for the moment.

Signed-off-by: Christian Berendt <berendt@osism.tech>