### PR TITLE
Re-enable most ansible-lint rules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,29 +1,30 @@
 ---
 exclude_paths:
-  - .github/
-  - contrib/rally
+  - .github
+  - .src
+  - .tox
+  - contrib
+  - doc
   - environments/kolla/files/overlays/prometheus/prometheus.yml.d/50-ceph.yml
   - netbox
-  - playbooks
+  - network
+  - scripts
+  - terraform
 mock_roles:
   - manager
+  - osism.commons.docker_compose
+  - osism.commons.operator
+  - osism.services.docker
+  - osism.services.manager
+  - osism.services.netbox
+  - osism.services.traefik
   - stage-output
 use_default_rules: true
 rulesdir:
   - ./.ansible-lint-rules/
 skip_list:
-  - parser-error  # AnsibleParserError.
-  - var-spacing  # Variables should have spaces before and after: {{ var_name }}.
-  - fqcn-builtins
   - yaml
-  - name[template]
 warn_list:
-  - experimental  # all rules tagged as experimental
   - command-instead-of-shell  # Use shell only when shell functionality is required.
-  - deprecated-command-syntax  # Using command rather than an argument to e.g. file.
-  - experimental  # all rules tagged as experimental
-  - fqcn[keyword]  # Use FQCN for builtin actions.
-  - name[casing]  # Rule for checking task and play names.
-  - name[missing]  # Rule for checking task and play names.
-  - no-changed-when  # Commands should not change things if nothing needs doing.
-  - risky-shell-pipe  # Shells that use pipes should set the pipefail option.
+  - no-changed-when           # Commands should not change things if nothing needs doing.
+  - run-once[task]            # Run once should use strategy other than free.

--- a/ansible/manager-part-0.yml
+++ b/ansible/manager-part-0.yml
@@ -15,7 +15,7 @@
         update_cache: true
         lock_timeout: "{{ apt_lock_timeout }}"
 
-    - name: Set APT options on manager
+    - name: Set APT options on manager  # noqa risky-shell-pipe
       become: true
       ansible.builtin.shell: |
         echo "APT::Acquire::Retries \"3\";" > /etc/apt/apt.conf.d/80-retries
@@ -72,10 +72,16 @@
         - osism/ansible-collection-commons
         - osism/ansible-collection-services
 
+    - name: Create /usr/share/ansible directory
+      become: true
+      ansible.builtin.file:
+        state: directory
+        path: /usr/share/ansible
+        mode: '0755'
+
     - name: Install collections
       become: true
       ansible.builtin.shell: |
-          mkdir -p /usr/share/ansible
           ansible-galaxy collection install --collections-path /usr/share/ansible/collections ansible.netcommon
           ansible-galaxy collection install --collections-path /usr/share/ansible/collections /opt/src/osism/ansible-collection-commons
           ansible-galaxy collection install --collections-path /usr/share/ansible/collections /opt/src/osism/ansible-collection-services
@@ -91,8 +97,5 @@
     operator_authorized_keys:
       - "{{ lookup('file', '.id_rsa.' + cloud_env + '.pub') }}"
 
-  collections:
-    - osism.commons
-
   roles:
-    - role: operator
+    - role: osism.commons.operator

--- a/ansible/manager-part-1.yml
+++ b/ansible/manager-part-1.yml
@@ -19,7 +19,7 @@
 
     - name: Copy SSH private key
       ansible.builtin.copy:
-        content: "{{ lookup('file', '.id_rsa.' + cloud_env ) }}\n"
+        content: "{{ lookup('file', '.id_rsa.' + cloud_env) }}\n"
         dest: .ssh/id_rsa
         mode: '0600'
         owner: "{{ operator_user }}"
@@ -47,7 +47,9 @@
           pip3 install --no-cache-dir python-gilt
       when: version_manager != "latest"
 
-    - name: Sync testbed repo with generics
+    # shell required because of: command module does not accept
+    # setting environment variables inline.
+    - name: Sync testbed repo with generics  # noqa command-instead-of-shell
       ansible.builtin.shell:
         chdir: /opt/configuration
         cmd: MANAGER_VERSION={{ version_manager }} gilt overlay

--- a/ansible/manager-part-2.yml
+++ b/ansible/manager-part-2.yml
@@ -12,11 +12,8 @@
     docker_user: dragon
     docker_version: "5:20.10.17"
 
-  collections:
-    - osism.services
-
   roles:
-    - docker
+    - osism.services.docker
 
 - name: Apply role docker_compose
   hosts: testbed-manager.testbed.osism.xyz
@@ -26,8 +23,5 @@
   vars:
     docker_compose_install_type: package
 
-  collections:
-    - osism.commons
-
   roles:
-    - role: docker_compose
+    - role: osism.commons.docker_compose

--- a/ansible/manager-part-3.yml
+++ b/ansible/manager-part-3.yml
@@ -55,12 +55,9 @@
     - /opt/configuration/environments/configuration.yml
     - /opt/configuration/environments/secrets.yml
 
-  collections:
-    - osism.services
-
   roles:
-    - traefik
-    - netbox
+    - osism.services.traefik
+    - osism.services.netbox
 
 - name: Apply role manager
   hosts: testbed-manager.testbed.osism.xyz
@@ -80,8 +77,5 @@
     - /opt/configuration/environments/configuration.yml
     - /opt/configuration/environments/secrets.yml
 
-  collections:
-    - osism.services
-
   roles:
-    - manager
+    - osism.services.manager

--- a/contrib/ansible/dns.yml
+++ b/contrib/ansible/dns.yml
@@ -1,5 +1,5 @@
 ---
-- name: set up DNS for testbed
+- name: Set up DNS for testbed
   hosts: localhost
   vars:
     cloud_provider: betacloud
@@ -35,14 +35,17 @@
       "testbed-node-9": "19"
 
   tasks:
-    - openstack.cloud.dns_zone:
+    - name: Create DNS zone
+      openstack.cloud.dns_zone:
         cloud: "{{ cloud_provider }}"
         state: present
         name: "{{ basedomain }}"
         zone_type: primary
         email: "{{ soa_email }}"
         ttl: "{{ ttl }}"
-    - openstack.cloud.recordset:
+
+    - name: Create DNS recordsets
+      openstack.cloud.recordset:
         cloud: "{{ cloud_provider }}"
         state: present
         zone: "{{ basedomain }}"

--- a/contrib/ownca/create_manager.yml
+++ b/contrib/ownca/create_manager.yml
@@ -34,7 +34,7 @@
       register: certificate
 
     - name: Write manager certificate file
-      copy:
+      ansible.builtin.copy:
         dest: testbed-manager.pem
         content: "{{ certificate.certificate }}"
       run_once: true

--- a/contrib/ownca/create_wildcard.yml
+++ b/contrib/ownca/create_wildcard.yml
@@ -32,7 +32,7 @@
       register: certificate
 
     - name: Write certificate file
-      copy:
+      ansible.builtin.copy:
         dest: testbed-certificate.pem
         content: "{{ certificate.certificate }}"
       run_once: true

--- a/environments/custom/playbook-keycloak-oidc-client-config.yml
+++ b/environments/custom/playbook-keycloak-oidc-client-config.yml
@@ -69,7 +69,7 @@
           create clients --target-realm "{{ keycloak_realm }}"
             --set clientId={{ keystone_client_id }}
             --set protocol=openid-connect
-            --set 'redirectUris={{ keystone_redirect_uris|tojson }}'
+            --set 'redirectUris={{ keystone_redirect_uris | tojson }}'
             --set standardFlowEnabled=true
             --set implicitFlowEnabled=true
             --set directAccessGrantsEnabled=true
@@ -79,7 +79,7 @@
       run_once: true
       no_log: true
 
-    - name: "Get internal ID for {{ keystone_client_id }} client"
+    - name: "Get internal ID for client {{ keystone_client_id }}"
       ansible.builtin.command: >-
         docker exec {{ keycloak_service_container_name }} {{ keycloak_kcadm_binary }}
           get clients --target-realm {{ keycloak_realm }}
@@ -91,7 +91,7 @@
       changed_when: false
       run_once: true
 
-    - name: "Filter internal ID for {{ keystone_client_id }} client"
+    - name: "Filter internal ID for client {{ keystone_client_id }}"
       ansible.builtin.set_fact:
         internal_client_id: "{{ internal_client_id_json.stdout }}"
       run_once: true

--- a/environments/manager/playbook-manager.yml
+++ b/environments/manager/playbook-manager.yml
@@ -4,11 +4,8 @@
 - name: Apply role manager
   hosts: manager
 
-  collections:
-    - osism.services
-
   roles:
-    - role: manager
+    - role: osism.services.manager
 
 - name: Restart manager service
   hosts: manager

--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -1,8 +1,6 @@
 ---
 - name: Prepare masquerading on the manager node
   hosts: testbed-managers
-  collections:
-    - ansible.builtin
 
   tasks:
     - name: Accpet FORWARD on the management interface (incoming)
@@ -30,8 +28,6 @@
 - name: Create SCS flavors
   hosts: localhost
   connection: local
-  collections:
-    - openstack.cloud
 
   tasks:
     # vCPU:RAM ratio: 4:8
@@ -199,9 +195,6 @@
 - name: Bootstrap basic OpenStack services
   hosts: localhost
   connection: local
-  collections:
-    - ansible.builtin
-    - openstack.cloud
 
   vars:
     openstack_version: yoga

--- a/environments/openstack/playbook-bootstrap-ceph-rgw.yml
+++ b/environments/openstack/playbook-bootstrap-ceph-rgw.yml
@@ -2,8 +2,6 @@
 - name: Bootstrap ceph rgw
   hosts: localhost
   connection: local
-  collections:
-    - openstack.cloud
 
   tasks:
     - name: Create swift service account

--- a/environments/openstack/playbook-bootstrap-images.yml
+++ b/environments/openstack/playbook-bootstrap-images.yml
@@ -4,9 +4,6 @@
 - name: Manage images
   hosts: localhost
   connection: local
-  collections:
-    - ansible.builtin
-    - openstack.cloud
 
   vars:
     url_ubuntu_image: https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img

--- a/environments/openstack/playbook-bootstrap-refstack.yml
+++ b/environments/openstack/playbook-bootstrap-refstack.yml
@@ -1,10 +1,6 @@
 ---
 - name: Bootstrap refstack
   hosts: localhost
-  collections:
-    - ansible.builtin
-    - community.general
-    - openstack.cloud
 
   vars:
     refstack_users:

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -34,11 +34,13 @@
         manager_host: "{{ manager_address.stdout | split('=') | last }}"
 
     - name: Update ansible collections
-      ansible.builtin.shell:
+      ansible.builtin.command:
         chdir: "{{ ansible_user_dir }}"
         cmd: |
-          {{ ansible_galaxy }} collection install --force "{{ repo_path }}/osism/ansible-collection-commons"
-          {{ ansible_galaxy }} collection install --force "{{ repo_path }}/osism/ansible-collection-services"
+          {{ ansible_galaxy }} collection install --force "{{ repo_path }}/osism/ansible-collection-{{ item }}"
+      loop:
+        - commons
+        - services
 
     - name: Wait up to 300 seconds for port 22 to become open and contain "OpenSSH"
       ansible.builtin.wait_for:
@@ -58,8 +60,7 @@
     - name: Get ssh keypair from terraform environment
       ansible.builtin.shell:
         chdir: "{{ ansible_path }}"
-        cmd: |
-          cp {{ terraform_path }}/.id* .
+        cmd: cp {{ terraform_path }}/.id* .
 
     - name: Point out that the following task takes some time and does not give any output
       ansible.builtin.debug:

--- a/playbooks/post.yml
+++ b/playbooks/post.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: Post clean play
+  hosts: all
 
   vars:
     cloud_env: "{{ testbed_environment | default('ci') }}"
@@ -10,7 +11,8 @@
         chdir: "{{ ansible_user_dir }}/src/github.com/osism/testbed/terraform"
         cmd: make ENVIRONMENT={{ cloud_env }} clean 2>&1
 
-- hosts: all
+- name: Post output play
+  hosts: all
 
   vars:
     stage_dir: "{{ ansible_user_dir }}/zuul-output"

--- a/playbooks/pre.yml
+++ b/playbooks/pre.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: Pre play
+  hosts: all
 
   vars:
     cloud_env: "{{ testbed_environment | default('ci') }}"

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -19,11 +19,11 @@
 
   tasks:
     - name: Run upgrade
-      ansible.builtin.shell:
+      ansible.builtin.command:
         chdir: "{{ basepath }}/terraform"
         cmd: make ENVIRONMENT={{ cloud_env }} VERSION_MANAGER={{ version_manager_next }} VERSION_CEPH={{ version_ceph_next }} VERSION_OPENSTACK={{ version_openstack_next }} upgrade
 
     - name: Run checks after the upgrade
-      ansible.builtin.shell:
+      ansible.builtin.command:
         chdir: "{{ basepath }}/terraform"
         cmd: make ENVIRONMENT={{ cloud_env }} check

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,11 @@ commands =
 
 [testenv:linters]
 deps =
-    ansible-lint
     ansible
+    ansible-lint
     doc8
     flake8
+    pytest
     yamllint
 commands =
   ansible-lint


### PR DESCRIPTION
In order to be able to fix the testbed quickly, the Ansible lint rules were deactivated as much as required for a short time. This change reverts that.

Related to 565f95ba0d60a67edc94dca5e4ac68f0610da70c.

Signed-off-by: Christian Berendt <berendt@osism.tech>