### PR TITLE
Fix ironic deployment in zed

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -89,7 +89,11 @@ enable_manila_backend_generic: "yes"
 
 # ironic
 ironic_dnsmasq_interface: "vxlan0"
+# NOTE: The ironic_dnsmasq_dhcp_range parameter was replaced with ironic_dnsmasq_dhcp_ranges
+#       in Zed. The ironic_dnsmasq_dhcp_range parameter can be removed in the future.
 ironic_dnsmasq_dhcp_range: "192.168.112.50,192.168.112.60"
+ironic_dnsmasq_dhcp_ranges:
+  - range: "192.168.112.50,192.168.112.60"
 ironic_cleaning_network: "public"
 
 ##########################################################


### PR DESCRIPTION
Add missing ironic_dnsmasq_dhcp_ranges parameter.

Signed-off-by: Christian Berendt <berendt@osism.tech>