### PR TITLE
zuul: add upgrade-next job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -51,6 +51,12 @@
       - name: orchestrator-wavestack
         label: testbed-orchestrator-wavecon
 
+- nodeset:
+    name: testbed-orchestrator-upgrade-next
+    nodes:
+      - name: orchestrator-wavestack
+        label: testbed-orchestrator-pco
+
 - job:
     name: testbed-deploy
     parent: base-extra-logs
@@ -76,6 +82,18 @@
     # be explictly bumped in the tenant configuration
     timeout: 16200
     nodeset: testbed-orchestrator-upgrade
+
+- job:
+    name: testbed-upgrade-next
+    parent: testbed-deploy
+    run: playbooks/upgrade.yml
+    # NOTE(frickler): Default zuul maximum timeout is 3h, this needs to
+    # be explictly bumped in the tenant configuration
+    timeout: 16200
+    vars:
+      openstack_version: yoga
+      openstack_version_next: zed
+    nodeset: testbed-orchestrator-upgrade-next
 
 - job:
     name: testbed-deploy-stable
@@ -131,6 +149,7 @@
         - testbed-deploy-next
         - testbed-deploy-stable
         - testbed-upgrade
+        - testbed-upgrade-next
     gate:
       jobs:
         - tox-docs
@@ -152,6 +171,7 @@
         - testbed-deploy-cleura
         - testbed-deploy-pco
         - testbed-deploy-wavestack
+        - testbed-upgrade-next
         - testbed-upgrade-cleura
         - testbed-upgrade-pco
         - testbed-upgrade-wavestack

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -2,9 +2,9 @@
 - name: Deploy testbed
   ansible.builtin.import_playbook: deploy.yml
   vars:
-    version_ceph: pacific
-    version_manager: latest
-    version_openstack: xena
+    version_ceph: "{{ ceph_version | default('pacific') }}"
+    version_manager: "{{ manager_version | default('latest') }}"
+    version_openstack: "{{ openstack_version | default('xena') }}"
 
 - name: Upgrade testbed
   hosts: all
@@ -12,9 +12,9 @@
   vars:
     basepath: "{{ ansible_user_dir }}/src/github.com/osism/testbed"
 
-    version_ceph_next: pacific
-    version_manager_next: latest
-    version_openstack_next: yoga
+    version_ceph_next: "{{ ceph_version_next | default('pacific') }}"
+    version_manager_next: "{{ manager_version_next | default('latest') }}"
+    version_openstack_next: "{{ openstack_version_next | default('yoga') }}"
 
   vars_files:
     - vars/cloud_envs.yml


### PR DESCRIPTION
This job will test the upgrade from our current ceph/openstack releases (pacific/yoga) to the next ceph/openstack releases (pacific/zed).

Signed-off-by: Christian Berendt <berendt@osism.tech>