### PR TITLE
Deploy/upgrade extended openstack services by default

### DIFF
--- a/scripts/deploy-services.sh
+++ b/scripts/deploy-services.sh
@@ -18,6 +18,7 @@ sh -c '/opt/configuration/scripts/deploy/100-ceph-services-basic.sh'
 sh -c '/opt/configuration/scripts/deploy/110-ceph-services-extended.sh'
 sh -c '/opt/configuration/scripts/deploy/200-infrastructure-services-basic.sh'
 sh -c '/opt/configuration/scripts/deploy/300-openstack-services-basic.sh'
+sh -c '/opt/configuration/scripts/deploy/310-openstack-services-extended.sh'
 sh -c '/opt/configuration/scripts/deploy/320-openstack-services-baremetal.sh'
 
 # deploy monitoring services

--- a/scripts/deploy/310-openstack-services-extended.sh
+++ b/scripts/deploy/310-openstack-services-extended.sh
@@ -5,8 +5,6 @@ export INTERACTIVE=false
 
 task_ids=$(osism apply --no-wait --format script gnocchi 2>&1)
 task_ids+=" "$(osism apply --no-wait --format script ceilometer 2>&1)
-task_ids+=" "$(osism apply --no-wait --format script aodh 2>&1)
 task_ids+=" "$(osism apply --no-wait --format script senlin 2>&1)
-task_ids+=" "$(osism apply --no-wait --format script heat 2>&1)
 
 osism wait --output --format script --delay 2 $task_ids

--- a/scripts/deploy/330-openstack-services-additional.sh
+++ b/scripts/deploy/330-openstack-services-additional.sh
@@ -3,6 +3,8 @@ set -e
 
 export INTERACTIVE=false
 
-osism apply influxdb
+task_ids+=" "$(osism apply --no-wait --format script aodh 2>&1)
+task_ids+=" "$(osism apply --no-wait --format script heat 2>&1)
+task_ids+=" "$(osism apply --no-wait --format script manila 2>&1)
 
-osism apply manila
+osism wait --output --format script --delay 2 $task_ids

--- a/scripts/upgrade-services.sh
+++ b/scripts/upgrade-services.sh
@@ -13,4 +13,5 @@ sh -c '/opt/configuration/scripts/upgrade/200-infrastructure-services-basic.sh'
 
 # upgrade openstack services
 sh -c '/opt/configuration/scripts/upgrade/300-openstack-services-basic.sh'
+sh -c '/opt/configuration/scripts/upgrade/310-openstack-services-extended.sh'
 sh -c '/opt/configuration/scripts/upgrade/320-openstack-services-baremetal.sh'

--- a/scripts/upgrade/310-openstack-services-extended.sh
+++ b/scripts/upgrade/310-openstack-services-extended.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+export INTERACTIVE=false
+
+task_ids=$(osism apply --no-wait --format script gnocchi -e kolla_action=upgrade 2>&1)
+task_ids+=" "$(osism apply --no-wait --format script ceilometer -e kolla_action=upgrade 2>&1)
+task_ids+=" "$(osism apply --no-wait --format script senlin -e kolla_action=upgrade 2>&1)
+
+osism wait --output --format script --delay 2 $task_ids

--- a/scripts/upgrade/330-openstack-services-additional.sh
+++ b/scripts/upgrade/330-openstack-services-additional.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+export INTERACTIVE=false
+
+task_ids+=" "$(osism apply --no-wait --format script aodh -e kolla_action=upgrade 2>&1)
+task_ids+=" "$(osism apply --no-wait --format script heat -e kolla_action=upgrade 2>&1)
+task_ids+=" "$(osism apply --no-wait --format script manila -e kolla_action=upgrade 2>&1)
+
+osism wait --output --format script --delay 2 $task_ids


### PR DESCRIPTION
This will deploy gnocchi, ceilometer, and, senlin.

Related to SovereignCloudStack/issues#271

Signed-off-by: Christian Berendt <berendt@osism.tech>