### PR TITLE
Update check_galera_cluster nagios plugin

### DIFF
--- a/contrib/nagios-plugins/check_galera_cluster
+++ b/contrib/nagios-plugins/check_galera_cluster
@@ -158,6 +158,7 @@ fi
 rClusterSize=$(mysql $param_mysql -B -N -e "show status like 'wsrep_cluster_size'"|cut -f 2)
 rClusterStatus=$(mysql $param_mysql -B -N -e "show status like 'wsrep_cluster_status'"|cut -f 2) # Primary
 rFlowControl=$(mysql $param_mysql -B -N -e "show status like 'wsrep_flow_control_paused'"|cut -f 2) # < 0.1
+rFlowControl=$(printf "%.14f" $rFlowControl)
 rReady=$(mysql $param_mysql -B -N -e "show status like 'wsrep_ready'"|cut -f 2)  # ON
 rConnected=$(mysql $param_mysql -B -N -e "show status like 'wsrep_connected'"|cut -f 2)  # ON
 rLocalStateComment=$(mysql $param_mysql -B -N -e "show status like 'wsrep_local_state_comment'"|cut -f 2)  # Synced


### PR DESCRIPTION
Sometimes wsrep_flow_control_paused can return a value in scientific notation that bc cannot handle, convert it to float.

[0] fridim/nagios-plugin-check_galera_cluster#4