### PR TITLE
Transfer ansible-lint to zuul job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -150,10 +150,12 @@
         - testbed-deploy-stable
         - testbed-upgrade
         - testbed-upgrade-next
+        - ansible-lint
     gate:
       jobs:
         - tox-docs
         - tox-linters
+        - ansible-lint
         - testbed-deploy:
             branches: main
         - testbed-deploy-next:

--- a/tox.ini
+++ b/tox.ini
@@ -14,13 +14,11 @@ commands =
 [testenv:linters]
 deps =
     ansible
-    ansible-lint
     doc8
     flake8
     pytest
     yamllint
 commands =
-  ansible-lint
   flake8
   yamllint -s .
   ansible-inventory -i inventory --list


### PR DESCRIPTION
Activate zuul job ansible-lint
Partly osism/issues#395

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
