### PR TITLE
Enable proxy

### DIFF
--- a/ansible/manager-part-3.yml
+++ b/ansible/manager-part-3.yml
@@ -41,7 +41,7 @@
 
   vars:
     ansible_python_interpreter: /usr/bin/python3
-    docker_registry_ansible: quay.io
+    docker_registry_netbox: osism.harbor.regio.digital
 
   vars_files:
     - /opt/configuration/inventory/group_vars/testbed-managers.yml
@@ -66,7 +66,7 @@
 
   vars:
     ansible_python_interpreter: /usr/bin/python3
-    docker_registry_ansible: quay.io
+    docker_registry_ansible: osism.harbor.regio.digital
     manager_service_restart: false
 
   vars_files:

--- a/environments/infrastructure/configuration.yml
+++ b/environments/infrastructure/configuration.yml
@@ -73,6 +73,28 @@ phpmyadmin_traefik: true
 
 squid_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface]['ipv4']['address'] }}"
 
+# NOTE: This can be removed in the future if the list of shared sources is
+#       in sync with the osism.services.squid role (or the ansible-defaults)
+#       used in the last stable release tested in the CI.
+squid_allowed_addresses:
+  - .archive.ubuntu.com
+  - .cloudfront.net
+  - .opendev.org
+  - .quay.io
+  - auth.docker.io
+  - download.docker.com
+  - galaxy.ansible.com
+  - github.com
+  - harbor.services.osism.tech
+  - index.docker.io
+  - minio.services.osism.tech
+  - osism.harbor.regio.digital
+  - packagecloud.io
+  - production.cloudflare.docker.com
+  - pypi.org
+  - registry-1.docker.io
+  - swift.services.a.regiocloud.tech
+
 ##########################
 # traefik
 

--- a/inventory/group_vars/testbed-nodes.yml
+++ b/inventory/group_vars/testbed-nodes.yml
@@ -17,6 +17,17 @@ netbox_inventory_tags:
 
 docker_network_mtu: "{{ testbed_mtu_node }}"
 
+docker_configure_proxy: true
+docker_proxy_http: "http://{{ groups['manager'][0] }}:3128"
+docker_proxy_https: "{{ docker_proxy_http }}"
+
+##########################################################
+# proxy
+
+proxy_proxies:
+  http: "http://{{ groups['manager'][0] }}:3128"
+  https: "http://{{ groups['manager'][0] }}:3128"
+
 ##########################################################
 # generic
 

--- a/scripts/000-pull-images.sh
+++ b/scripts/000-pull-images.sh
@@ -9,6 +9,7 @@ cinder
 common
 designate
 glance
+grafana
 heat
 horizon
 keystone
@@ -18,6 +19,7 @@ memcached
 neutron
 nova
 octavia
+opensearch
 openvswitch
 ovn
 placement

--- a/scripts/deploy-manager.sh
+++ b/scripts/deploy-manager.sh
@@ -40,7 +40,6 @@ osism apply network
 # deploy wireguard
 osism apply wireguard
 
-
 # On OSISM < 5.0.0 this file is not yet present.
 if [[ -e /home/dragon/wg0-dragon.conf ]]; then
     mv /home/dragon/wg0-dragon.conf /home/dragon/wireguard-client.conf

--- a/scripts/deploy/000-manager-service.sh
+++ b/scripts/deploy/000-manager-service.sh
@@ -62,3 +62,5 @@ osism netbox disable --no-wait testbed-switch-2
 
 osism apply sshconfig
 osism apply known-hosts
+
+osism apply squid


### PR DESCRIPTION
This change adds a squid proxy that allows only whitelisted traffic to every component, that is set to use this proxy.

partly #1439 

Signed-off-by: Tim Beermann <beermann@osism.tech>
