### PR TITLE
fixes sending metrics also to gnocchi

### DIFF
--- a/environments/kolla/files/overlays/ceilometer/pipeline.yaml
+++ b/environments/kolla/files/overlays/ceilometer/pipeline.yaml
@@ -5,7 +5,11 @@ sources:
       - "*"
     sinks:
       - meter_sink
+      - gnocchi
 sinks:
   - name: meter_sink
     publishers:
       - prometheus://testbed-manager-0.testbed.osism.xyz/metrics/job/openstack-telemetry
+  - name: gnocchi
+    publishers:
+      - gnocchi://testbed-manager-0.testbed.osism.xyz


### PR DESCRIPTION
ceilometer is not configured to use gnocchi as sink.
this PR fixes that