### PR TITLE
Use mariadb as backend for ara

### DIFF
--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -40,7 +40,6 @@ osism_api_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface
 
 ara_enable: true
 
-ara_server_database_type: sqlite3
 ara_server_host: ara.testbed.osism.xyz
 ara_server_traefik: true
 


### PR DESCRIPTION
According to https://ara.recordsansible.org/blog/2023/02/26/ benchmarking-ara-with-different-databases-and-python3.11-for fun-and-science/ ARA with MariaDB as backend is faster.

This way we also ensure that the MariaDB/ARA integration is working like expected.

Closes osism/issues#439