### PR TITLE
ceph: use keystone port 5000 instead of 35357

### DIFF
--- a/environments/ceph/configuration.yml
+++ b/environments/ceph/configuration.yml
@@ -55,7 +55,7 @@ ceph_conf_overrides:
     "rgw keystone admin user": "swift"
     "rgw keystone api version": "3"
     "rgw keystone revocation interval": "900"
-    "rgw keystone url": "http://api-int.testbed.osism.xyz:35357"
+    "rgw keystone url": "http://api-int.testbed.osism.xyz:5000"
     "rgw keystone implicit tenants": "true"
     "rgw s3 auth use keystone": "true"
     "rgw swift account in url": "true"


### PR DESCRIPTION
Part of osism/issues#459