### PR TITLE
Adapt wireguard config to modified role

### DIFF
--- a/environments/infrastructure/configuration.yml
+++ b/environments/infrastructure/configuration.yml
@@ -79,3 +79,12 @@ squid_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface]['i
 traefik_enable: true
 
 traefik_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface]['ipv4']['address'] }}"
+
+##########################
+# wireguard
+
+wireguard_users:
+  - name: dragon
+    key: LDweUZxqy/0AieSVw3baZmbRMPBqhfDUcuLAwSYyQkE=
+    ip: 192.168.48.4
+wireguard_create_client_config: true

--- a/scripts/deploy-manager.sh
+++ b/scripts/deploy-manager.sh
@@ -39,7 +39,15 @@ osism apply network
 
 # deploy wireguard
 osism apply wireguard
+
+
+# On OSISM < 5.0.0 this file is not yet present.
+if [[ -e /home/dragon/wg0-dragon.conf ]]; then
+    mv /home/dragon/wg0-dragon.conf /home/dragon/wireguard-client.conf
+fi
+
 sed -i -e s/WIREGUARD_PUBLIC_IP_ADDRESS/$(curl my.ip.fi)/ /home/dragon/wireguard-client.conf
+sed -i -e "s/CHANGEME - dragon private key/GEQ5eWshKW+4ZhXMcWkAAbqzj7QA9G64oBFB3CbrR0w=/" /home/dragon/wireguard-client.conf
 
 # apply workarounds
 osism apply --environment custom workarounds


### PR DESCRIPTION
The new wireguard role needs some options being set in the configuration in order to deploy the same setup as before.

Depends-On: https://github.com/osism/ansible-collection-services/pull/927