### PR TITLE
Fix upgrade script

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -26,8 +26,8 @@ export INTERACTIVE=false
 # Sync testbed repo with generics
 pushd /opt/configuration
 pip3 install --no-cache-dir python-gilt
-gilt overlay
-gilt overlay
+/home/dragon/.local/bin/gilt overlay
+/home/dragon/.local/bin/gilt overlay
 popd
 
 # upgrade manager


### PR DESCRIPTION
WARNING: The script gilt is installed in '/home/dragon/.local/bin' which is not on PATH.