### PR TITLE
Fix idempotency for deployment script

### DIFF
--- a/scripts/disable-ara.sh
+++ b/scripts/disable-ara.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-docker exec -t ceph-ansible mv /ansible/ara.env /ansible/ara.env.disabled
-docker exec -t kolla-ansible mv /ansible/ara.env /ansible/ara.env.disabled
-docker exec -t osism-ansible mv /ansible/ara.env /ansible/ara.env.disabled
+docker exec -t ceph-ansible mv /ansible/ara.env /ansible/ara.env.disabled || true
+docker exec -t kolla-ansible mv /ansible/ara.env /ansible/ara.env.disabled || true
+docker exec -t osism-ansible mv /ansible/ara.env /ansible/ara.env.disabled || true


### PR DESCRIPTION
When a deployment was interrupted and restarted, there would be errors in the disable-ara.sh script. Simply ignore those errors.