### PR TITLE
Use Authorization Code flow with PKCE in Keycloak OIDC federation

### DIFF
--- a/environments/custom/playbook-keycloak-oidc-client-config.yml
+++ b/environments/custom/playbook-keycloak-oidc-client-config.yml
@@ -73,8 +73,9 @@
             --set standardFlowEnabled=true
             --set implicitFlowEnabled=true
             --set directAccessGrantsEnabled=true
-            --set publicClient=false
+            --set publicClient=true
             --set secret="{{ keystone_container_federation_oidc_client_secret }}"
+            --set 'attributes."pkce.code.challenge.method"="plain"'
       when: keystone_client_id not in available_clients
       run_once: true
       no_log: true

--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -46,6 +46,7 @@ elasticsearch_curator_hard_retention_period_days: 1
 # keystone
 enable_keystone_federation: "yes"
 keystone_enable_federation_openid: "yes"
+keystone_federation_oidc_response_type: "code"
 keystone_identity_providers:
   - name: "keycloak"
     openstack_domain: "keycloak"

--- a/environments/kolla/files/overlays/keystone/wsgi-keystone.conf
+++ b/environments/kolla/files/overlays/keystone/wsgi-keystone.conf
@@ -55,7 +55,8 @@ LogLevel info
 
 {% if keystone_enable_federation_openid %}
     OIDCClaimPrefix "OIDC-"
-    OIDCClaimDelimiter ";"
+    OIDCClaimDelimiter ","
+    OIDCPKCEMethod plain
     OIDCResponseType "{{ keystone_federation_oidc_response_type }}"
     OIDCScope "{{ keystone_federation_oidc_scopes }}"
 #   OIDCMetadataDir {{ keystone_container_federation_oidc_metadata_folder }}


### PR DESCRIPTION
Changes to use Authorization Code flow with PKCE in Keycloak for security reasons.

@matfechner 

https://github.com/SovereignCloudStack/issues/issues/293