### PR TITLE
add Huaweicloud as supported list of clouds for testbed.

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -17,6 +17,7 @@ OVH              | OVH           | **ovh**
 OpenTelekomCloud | T-Systems     | **otc**
 Wavestack        | noris network | **wavestack**
 pluscloud open   | plusserver    | **pluscloudopen**
+HuaweiCloud      | HuaweiCloud   | **huaweicloud**
 
 Terraform must be installed and usable. Information on installing Terraform can be found in the [Terraform documentation](https://learn.hashicorp.com/tutorials/terraform/install-cli)
 Currently Terraform **>= 1.2.0** is supported.

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -203,4 +203,32 @@ export ENVIRONMENT=betacloud
 >     auth_type: "v3applicationcredential"
 > ```
 
+* [HuaweiCloud](https://www.huaweicloud.com/eu/)
+
+:::note
+
+>**note:**
+>
+> * Registration is possible via https://www.huaweicloud.com/eu/
+> * The credentials are stored in **clouds.yaml** and **secure.yaml** with the name **huaweicloud**.
+> * Credential details can be taken from the "MyCredentials" option in the admin console: <https://console.eu.huaweicloud.com/iam>.
+>
+> ```yaml
+> ---
+> clouds:
+>   huaweicloud:
+>     auth:
+>       auth_url: https://iam.myhuaweicloud.eu/
+>       password: xxxx
+>       username: xxxx
+>       project_name: 'PROJECT_NAME'
+>       project_domain_name: 'PROJECT_DOMAIN_NAME'
+>       user_domain_name: 'USER_DOMAIN_NAME'
+>       identity_api_version: 3
+>       block_storage_api_version: 3
+>       regions:
+>         - name: Dublin
+
+
+
 :::

--- a/terraform/environments/huaweicloud.tfvars
+++ b/terraform/environments/huaweicloud.tfvars
@@ -1,0 +1,17 @@
+# customisation:access_floatingip
+# customisation:default
+# customisation:neutron_floatingip
+# override:manager_boot_from_volume
+# override:neutron_router_enable_snat
+# override:nodes_boot_from_volume
+availability_zone         = "eu-west-101b"
+volume_availability_zone  = "eu-west-101b"
+network_availability_zone = "eu-west-101b"
+flavor_node               = "c6s.4xlarge.2"
+flavor_manager            = "s6.2xlarge.2"
+image                     = "Ubuntu 22.04 server 64bit"
+image_node                = "Ubuntu 22.04 server 64bit"
+volume_size_storage       = 50
+public                    = "admin_external_net"
+dns_nameservers           = ["9.9.9.9"]
+number_of_volumes         = 3


### PR DESCRIPTION
Hi, we tried to install the test bed on Huaweicloud EU region and it worked. So updating the documentation to reflect the same. 
Thank you.