### PR TITLE
Fix renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
     },
     {
       "fileMatch":[
-        "^\\playbooks\\/.*\\.yml"
+        "^playbooks\\/.*\\.yml"
       ],
       "matchStrings":[
         "terragrunt_version: (?<currentValue>.*?)  # renovate: datasource=github-tags depName=gruntwork-io/terragrunt\n"


### PR DESCRIPTION
relates https://github.com/osism/testbed/issues/593

There was a false file match regex expression. Probably due to copy paste.

Signed-off-by: Tim Beermann <beermann@osism.tech>
