### PR TITLE
remove colored output from terraform by default

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -7,6 +7,7 @@ USERNAME = dragon
 
 OPENSTACK = openstack
 TERRAFORM ?= terraform
+export TF_CLI_ARGS ?= -no-color
 
 PARALLELISM = 10
 RESOURCE = openstack_networking_floatingip_v2.manager_floating_ip


### PR DESCRIPTION
I was told this is an issue in our log output, for example here:

https://logs.services.betacloud.xyz/periodic-daily/github.com/osism/testbed/main/testbed-deploy/75b3979/job-output.txt

this can be overridden by overwriting TF_CLI_ARGS

see the upstream docs for details:

https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_cli_args-and-tf_cli_args_name

if some subcommand does not support this feature, this is considered
a bug and should be reported, according to this message:

https://github.com/hashicorp/terraform/issues/15264#issuecomment-1158930479

Signed-off-by: Sven Kieske <kieske@osism.tech>