### PR TITLE
Add more retry rules in Terragrunt configuration

### DIFF
--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -1,4 +1,6 @@
 retryable_errors = [
     "(?s).*operation timed out.*",
     "(?s).*The backend server is unreachable.*",
+    "(?s).*Quota exceeded for resources.*",
+    "(?s).*Error waiting for instance.*",
 ]


### PR DESCRIPTION
Quota exceeded for resources: The quota might be taken up by an ongoing cleanup, so a retry might be useful.

Error waiting for instance: Sometimes an instance does not come up correctly, a retry then makes sense.