### PR TITLE
Move the bootstrap from services to its own script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ deploy: bootstrap ## Deploy everything and then check it.
 	make -C terraform \
 	  ENVIRONMENT=$(ENVIRONMENT) \
 	  TERRAFORM=$(TERRAFORM) \
+	  bootstrap
+	make -C terraform \
+	  ENVIRONMENT=$(ENVIRONMENT) \
+	  TERRAFORM=$(TERRAFORM) \
 	  check
 
 prepare: ## Run local preparations.

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -19,6 +19,8 @@
     version_manager: "{{ manager_version | default('latest') }}"
     version_openstack: "{{ openstack_version | default('zed') }}"
 
+    run_bootstrap: true
+    run_checks: true
     run_refstack: "{{ refstack | default(false) | bool }}"
 
   vars_files:
@@ -122,16 +124,26 @@
         cmd: "ssh -i {{ terraform_path }}/.id_rsa.{{ cloud_env }} dragon@{{ manager_host }} /opt/configuration/scripts/deploy-services.sh"
       when: not manual_deploy | bool
 
+    - name: Bootstrap services
+      ansible.builtin.shell:
+        chdir: "{{ terraform_path }}"
+        cmd: make ENVIRONMENT={{ cloud_env }} bootstrap
+      when:
+        - not manual_deploy | bool
+        - run_bootstrap | bool
+
     - name: Run checks
       ansible.builtin.shell:
         chdir: "{{ terraform_path }}"
-        cmd: make ENVIRONMENT={{ cloud_env }} TERRAFORM={{ terraform_binary }} check
-      when: not manual_deploy | bool
+        cmd: make ENVIRONMENT={{ cloud_env }} check
+      when:
+        - not manual_deploy | bool
+        - run_checks | bool
 
     - name: Run refstack
       ansible.builtin.shell:
         chdir: "{{ terraform_path }}"
-        cmd: make ENVIRONMENT={{ cloud_env }} TERRAFORM={{ terraform_binary }} refstack
+        cmd: make ENVIRONMENT={{ cloud_env }} refstack
       when:
         - not manual_deploy | bool
         - run_refstack | bool

--- a/playbooks/upgrade-stable.yml
+++ b/playbooks/upgrade-stable.yml
@@ -4,6 +4,8 @@
   vars:
     version_manager: "{{ manager_version | default('latest') }}"
 
+    run_bootstrap: false
+
 - name: Upgrade testbed
   hosts: all
 
@@ -12,6 +14,9 @@
     terraform_path: "{{ basepath }}/terraform"
 
     version_manager_next: "{{ manager_version_next | default('latest') }}"
+
+    run_bootstrap: true
+    run_checks: true
 
   vars_files:
     - vars/cloud_envs.yml
@@ -32,7 +37,14 @@
         chdir: "{{ terraform_path }}"
         cmd: make ENVIRONMENT={{ cloud_env }} VERSION_MANAGER={{ version_manager_next }} upgrade
 
+    - name: Bootstrap services
+      ansible.builtin.shell:
+        chdir: "{{ terraform_path }}"
+        cmd: make ENVIRONMENT={{ cloud_env }} bootstrap
+      when: run_bootstrap | bool
+
     - name: Run checks after the upgrade
       ansible.builtin.command:
         chdir: "{{ terraform_path }}"
         cmd: make ENVIRONMENT={{ cloud_env }} check
+      when: run_checks | bool

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -6,6 +6,8 @@
     version_manager: "{{ manager_version | default('latest') }}"
     version_openstack: "{{ openstack_version | default('yoga') }}"
 
+    run_bootstrap: false
+
 - name: Upgrade testbed
   hosts: all
 
@@ -18,6 +20,8 @@
     version_ceph_next: "{{ ceph_version_next | default('pacific') }}"
     version_manager_next: "{{ manager_version_next | default('latest') }}"
     version_openstack_next: "{{ openstack_version_next | default('zed') }}"
+
+    run_bootstrap: true
 
   vars_files:
     - vars/cloud_envs.yml
@@ -38,7 +42,13 @@
         chdir: "{{ terraform_path }}"
         cmd: make ENVIRONMENT={{ cloud_env }} TERRAFORM={{ terraform_binary }} VERSION_MANAGER={{ version_manager_next }} VERSION_CEPH={{ version_ceph_next }} VERSION_OPENSTACK={{ version_openstack_next }} upgrade
 
+    - name: Bootstrap services
+      ansible.builtin.shell:
+        chdir: "{{ terraform_path }}"
+        cmd: make ENVIRONMENT={{ cloud_env }} bootstrap
+      when: run_bootstrap | bool
+
     - name: Run checks after the upgrade
       ansible.builtin.command:
         chdir: "{{ terraform_path }}"
-        cmd: make ENVIRONMENT={{ cloud_env }} TERRAFORM={{ terraform_binary }} check
+        cmd: make ENVIRONMENT={{ cloud_env }} check

--- a/scripts/bootstrap-services.sh
+++ b/scripts/bootstrap-services.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+sh -c '/opt/configuration/scripts/bootstrap/300-openstack-services.sh'

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+echo
+echo "# BOOTSTRAP"
+echo
+
+# bootstrap services
+sh -c '/opt/configuration/scripts/bootstrap-services.sh'

--- a/scripts/bootstrap/300-openstack-services.sh
+++ b/scripts/bootstrap/300-openstack-services.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+export INTERACTIVE=false
+
+MANAGER_VERSION=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version"}}' osism-ansible)
+OPENSTACK_VERSION=$(docker inspect --format '{{ index .Config.Labels "de.osism.release.openstack"}}' kolla-ansible)
+
+osism apply --environment openstack bootstrap-flavors
+osism apply --environment openstack bootstrap-basic -e openstack_version=$OPENSTACK_VERSION
+osism apply --environment openstack bootstrap-ceph-rgw
+
+# osism manage images is only available since 5.0.0. To enable the
+# testbed to be used with < 5.0.0, here is this check.
+if [[ $MANAGER_VERSION == "4.0.0" || $MANAGER_VERSION == "4.1.0" || $MANAGER_VERSION == "4.2.0" || $MANAGER_VERSION == "4.3.0" ]]; then
+    osism apply --environment openstack bootstrap-images
+else
+    osism manage images --cloud admin --filter Cirros
+    osism manage images --cloud admin --filter "Ubuntu 22.04 Minimal"
+fi
+
+if [[ "$REFSTACK" == "false" ]]; then
+    osism apply --environment openstack test
+    osism apply openstack-health-monitor
+fi

--- a/scripts/deploy/300-openstack-services-basic.sh
+++ b/scripts/deploy/300-openstack-services-basic.sh
@@ -22,21 +22,3 @@ if [[ "$REFSTACK" == "false" ]]; then
 fi
 
 osism wait --output --format script --delay 2 $task_ids
-
-osism apply --environment openstack bootstrap-flavors
-osism apply --environment openstack bootstrap-basic -e openstack_version=$OPENSTACK_VERSION
-osism apply --environment openstack bootstrap-ceph-rgw
-
-# osism manage images is only available since 5.0.0. To enable the
-# testbed to be used with < 5.0.0, here is this check.
-if [[ $MANAGER_VERSION == "4.0.0" || $MANAGER_VERSION == "4.1.0" || $MANAGER_VERSION == "4.2.0" || $MANAGER_VERSION == "4.3.0" ]]; then
-    osism apply --environment openstack bootstrap-images
-else
-    osism manage images --cloud admin --filter Cirros
-    osism manage images --cloud admin --filter "Ubuntu 22.04 Minimal"
-fi
-
-if [[ "$REFSTACK" == "false" ]]; then
-    osism apply --environment openstack test
-    osism apply openstack-health-monitor
-fi

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -123,6 +123,10 @@ refstack: .MANAGER_ADDRESS.$(ENVIRONMENT) .id_rsa.$(ENVIRONMENT)
 	@. ./.MANAGER_ADDRESS.$(ENVIRONMENT); \
 	ssh -o StrictHostKeyChecking=no -i .id_rsa.$(ENVIRONMENT) $(USERNAME)@$$MANAGER_ADDRESS /opt/configuration/scripts/check/301-openstack-refstack.sh
 
+bootstrap: .MANAGER_ADDRESS.$(ENVIRONMENT) .id_rsa.$(ENVIRONMENT)
+	@. ./.MANAGER_ADDRESS.$(ENVIRONMENT); \
+	ssh -o StrictHostKeyChecking=no -i .id_rsa.$(ENVIRONMENT) $(USERNAME)@$$MANAGER_ADDRESS /opt/configuration/scripts/bootstrap.sh
+
 graph: init
 	@$(TERRAFORM) graph
 
@@ -217,4 +221,4 @@ plan: dry-run
 push: state-push
 tunnel: sshuttle
 
-PHONY: clean console attach detach sshuttle ssh dry-run list deploy deploy-identity deploy-manager upgrade watch openstack create log login scp copy address check rally refstack deploy-ceph upgrade-ceph
+PHONY: clean console attach detach sshuttle ssh dry-run list deploy deploy-identity deploy-manager upgrade watch openstack create log login scp copy address check rally refstack deploy-ceph upgrade-ceph bootstrap


### PR DESCRIPTION
This makes it possible to not run the bootstrap multiple times when using an upgrade job.