### PR TITLE
refactoring the osism version logic

### DIFF
--- a/scripts/bootstrap/300-openstack-services.sh
+++ b/scripts/bootstrap/300-openstack-services.sh
@@ -12,7 +12,7 @@ osism apply --environment openstack bootstrap-ceph-rgw
 
 # osism manage images is only available since 5.0.0. To enable the
 # testbed to be used with < 5.0.0, here is this check.
-if [[ $MANAGER_VERSION == "4.0.0" || $MANAGER_VERSION == "4.1.0" || $MANAGER_VERSION == "4.2.0" || $MANAGER_VERSION == "4.3.0" ]]; then
+if [[ $MANAGER_VERSION =~ ^4\.[0-9]\.[0-9]$ ]]; then
     osism apply --environment openstack bootstrap-images
 else
     osism manage images --cloud admin --filter Cirros

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -15,7 +15,7 @@ echo
 for node in testbed-manager testbed-node-0 testbed-node-1 testbed-node-2; do
     # osism container is only available since 5.0.0. To enable the
     # testbed to be used with < 5.0.0, here is this check.
-    if [[ $MANAGER_VERSION == "4.0.0" || $MANAGER_VERSION == "4.1.0" || $MANAGER_VERSION == "4.2.0" || $MANAGER_VERSION == "4.3.0" ]]; then
+    if [[ $MANAGER_VERSION =~ ^4\.[0-9]\.[0-9]$ ]]; then
         echo
         echo "## Containers @ $node"
         echo

--- a/scripts/deploy/100-ceph-services-basic.sh
+++ b/scripts/deploy/100-ceph-services-basic.sh
@@ -12,17 +12,17 @@ fi
 
 MANAGER_VERSION=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version"}}' osism-ansible)
 if [[ "$REFSTACK" == "false" ]]; then
-    if [[ $MANAGER_VERSION == "4.0.0" || $MANAGER_VERSION == "4.1.0" || $MANAGER_VERSION == "4.2.0" || $MANAGER_VERSION == "4.3.0" ]]; then
+    if [[ $MANAGER_VERSION =~ ^4\.[0-9]\.[0-9]$ ]]; then
         osism apply ceph-base
         task_ids=$(osism apply --no-wait --format script ceph-mdss 2>&1)
         task_ids+=" "$(osism apply --no-wait --format script ceph-rgws 2>&1)
 
-        osism wait --output --format script --delay 2 $task_ids
+        osism wait --output --format script --delay 2 "$task_ids"
     else
         osism apply ceph -e enable_ceph_mds=true -e enable_ceph_rgw=true
     fi
 else
-    if [[ $MANAGER_VERSION == "4.0.0" || $MANAGER_VERSION == "4.1.0" || $MANAGER_VERSION == "4.2.0" || $MANAGER_VERSION == "4.3.0" ]]; then
+    if [[ $MANAGER_VERSION =~ ^4\.[0-9]\.[0-9]$ ]]; then
         osism apply ceph-base
     else
         osism apply ceph
@@ -38,7 +38,7 @@ ceph config set mon auth_allow_insecure_global_id_reclaim false
 # osism validate is only available since 5.0.0. To enable the
 # testbed to be used with < 5.0.0, here is this check.
 MANAGER_VERSION=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version"}}' osism-ansible)
-if [[ $MANAGER_VERSION == "4.0.0" || $MANAGER_VERSION == "4.1.0" || $MANAGER_VERSION == "4.2.0" || $MANAGER_VERSION == "4.3.0" ]]; then
+if [[ $MANAGER_VERSION =~ ^4\.[0-9]\.[0-9]$ ]]; then
     echo "ceph validate not possible with OSISM < 4.3.0"
 else
     osism apply facts

--- a/scripts/deploy/310-openstack-services-extended.sh
+++ b/scripts/deploy/310-openstack-services-extended.sh
@@ -6,17 +6,17 @@ export INTERACTIVE=false
 task_ids=$(osism apply --no-wait --format script gnocchi 2>&1)
 task_ids+=" "$(osism apply --no-wait --format script prometheus 2>&1)
 
-osism wait --output --format script --delay 2 $task_ids
+osism wait --output --format script --delay 2 "$task_ids"
 
 task_ids=$(osism apply --no-wait --format script ceilometer2>&1)
 task_ids+=" "$(osism apply --no-wait --format script heat 2>&1)
 task_ids+=" "$(osism apply --no-wait --format script senlin 2>&1)
 
 MANAGER_VERSION=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version"}}' osism-ansible)
-if [[ $MANAGER_VERSION == "4.0.0" || $MANAGER_VERSION == "4.1.0" || $MANAGER_VERSION == "4.2.0" || $MANAGER_VERSION == "4.3.0" ]]; then
+if [[ $MANAGER_VERSION =~ ^4\.[0-9]\.[0-9]$ ]]; then
     echo "Skip Skyline deployment before OSISM < 5.0.0"
 else
     task_ids+=" "$(osism apply --no-wait --format script skyline 2>&1)
 fi
 
-osism wait --output --format script --delay 2 $task_ids
+osism wait --output --format script --delay 2 "$task_ids"

--- a/scripts/upgrade/310-openstack-services-extended.sh
+++ b/scripts/upgrade/310-openstack-services-extended.sh
@@ -6,17 +6,17 @@ export INTERACTIVE=false
 task_ids=$(osism apply --no-wait --format script gnocchi -e kolla_action=upgrade 2>&1)
 task_ids+=" "$(osism apply --no-wait --format script prometheus -e kolla_action=upgrade 2>&1)
 
-osism wait --output --format script --delay 2 $task_ids
+osism wait --output --format script --delay 2 "$task_ids"
 
 task_ids=$(osism apply --no-wait --format script ceilometer-e kolla_action=upgrade 2>&1)
 task_ids+=" "$(osism apply --no-wait --format script heat -e kolla_action=upgrade 2>&1)
 task_ids+=" "$(osism apply --no-wait --format script senlin -e kolla_action=upgrade 2>&1)
 
 MANAGER_VERSION=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version"}}' osism-ansible)
-if [[ $MANAGER_VERSION == "4.0.0" || $MANAGER_VERSION == "4.1.0" || $MANAGER_VERSION == "4.2.0" || $MANAGER_VERSION == "4.3.0" ]]; then
+if [[ $MANAGER_VERSION =~ ^4\.[0-9]\.[0-9]$ ]]; then
     echo "Skip Skyline deployment before OSISM < 5.0.0"
 else
     task_ids+=" "$(osism apply --no-wait --format script skyline -e kolla_action=upgrade 2>&1)
 fi
 
-osism wait --output --format script --delay 2 $task_ids
+osism wait --output --format script --delay 2 "$task_ids"


### PR DESCRIPTION
don't install skyline for osism < 5
also fix 2 minor shellcheck issues around variable quoting.

Signed-off-by: Sven Kieske <kieske@osism.tech>