### PR TITLE
Remove virtualbmc service

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -74,11 +74,6 @@ neutron_ovn_availability_zones:
 enable_neutron_agent_ha: "yes"
 
 # nova
-# NOTE: This volume is only needed in the testbed so that the virtualbmc service
-#       can access the Libvirt sockets.
-nova_libvirt_extra_volumes:
-  - "nova_libvirt_run:/var/run/libvirt"
-
 # NOTE: Disable the debugging logs for Libvirt as Libvirt writes a lot of logs
 #       that are not of interest.
 nova_libvirt_logging_debug: "no"

--- a/scripts/deploy/320-openstack-services-baremetal.sh
+++ b/scripts/deploy/320-openstack-services-baremetal.sh
@@ -8,10 +8,4 @@ OPENSTACK_VERSION=$(docker inspect --format '{{ index .Config.Labels "de.osism.r
 curl https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos8-stable-${OPENSTACK_VERSION}.kernel -o /opt/configuration/environments/kolla/files/overlays/ironic/ironic-agent.kernel
 curl https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos8-stable-${OPENSTACK_VERSION}.initramfs -o /opt/configuration/environments/kolla/files/overlays/ironic/ironic-agent.initramfs
 
-# NOTE: The docker-compose role is currently required for the
-#       virtualbmc service. Can be removed again when everything
-#       has been switched to the docker compose cli plugin.
-osism apply docker-compose
-
-osism apply virtualbmc
 osism apply ironic


### PR DESCRIPTION
The virtualbmc service was included as a workaround to test Ironic for functionality within the testbed. In the future we will have access to real baremetal systems to perform real tests of Ironic. Therefore, the approach to use emulated baremetal systems within the testbed will not be pursued further. The deployment of Ironic continues to be tested in the testbed.