### PR TITLE
Configure chrony with cloud-init

### DIFF
--- a/terraform/customisations/default_custom.tf
+++ b/terraform/customisations/default_custom.tf
@@ -24,9 +24,15 @@ network:
    config: disabled
 mounts:
   - [ ephemeral0, null ]
+ntp:
+  enabled: true
+  ntp_client: chrony
 package_update: true
 package_upgrade: true
 runcmd:
+  - "chronyc -a makestep"
+  - "apt-get update"
+  - "touch /var/lib/apt/periodic/update-success-stamp"
   - "echo 'network: {config: disabled}' > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg"
 final_message: "The system is finally up, after $UPTIME seconds"
 EOT

--- a/terraform/manager.tf
+++ b/terraform/manager.tf
@@ -39,8 +39,11 @@ resource "openstack_compute_instance_v2" "manager_server" {
 #cloud-config
 network:
    config: disabled
-package_update: false
-package_upgrade: false
+ntp:
+  enabled: true
+  ntp_client: chrony
+package_update: true
+package_upgrade: true
 write_files:
   - content: ${openstack_compute_keypair_v2.key.public_key}
     path: /home/ubuntu/.ssh/id_rsa.pub
@@ -64,6 +67,9 @@ write_files:
     path: /opt/manager-vars.sh
     permissions: '0644'
 runcmd:
+  - "chronyc -a makestep"
+  - "apt-get update"
+  - "touch /var/lib/apt/periodic/update-success-stamp"
   - "echo 'network: {config: disabled}' > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg"
   - "chown -R ubuntu:ubuntu /home/ubuntu"
 final_message: "The system is finally up, after $UPTIME seconds"


### PR DESCRIPTION
Sometimes it happens that the system time is not correct after a boot. This then leads to anomalies in the bootstrap process. For example, the mtime on certain files is incorrect as a result. To work around the problem in the testbed, Chrony is already deployed with cloud-init. Thus a correct system time is available directly after the boot even before the bootstrap process was executed.

$ stat /var/lib/apt/periodic/update-success-stamp
  File: /var/lib/apt/periodic/update-success-stamp
  Size: 0         	Blocks: 0          IO Block: 4096   regular empty file
Device: 801h/2049d	Inode: 69167       Links: 1
Access: (0644/-rw-r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2023-05-12 10:26:37.609383906 +0000
Modify: 2023-05-12 10:36:46.308000000 +0000
Change: 2023-05-12 10:36:46.308000000 +0000
 Birth: 2023-04-28 02:10:21.728204937 +0000