### PR TITLE
Do not update packages with cloud-init on the manager

### DIFF
--- a/ansible/manager-part-3.yml
+++ b/ansible/manager-part-3.yml
@@ -67,6 +67,7 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
     docker_registry_ansible: quay.io
+    manager_service_restart: false
 
   vars_files:
     - /opt/configuration/inventory/group_vars/testbed-managers.yml

--- a/terraform/manager.tf
+++ b/terraform/manager.tf
@@ -43,7 +43,7 @@ ntp:
   enabled: true
   ntp_client: chrony
 package_update: true
-package_upgrade: true
+package_upgrade: false
 write_files:
   - content: ${openstack_compute_keypair_v2.key.public_key}
     path: /home/ubuntu/.ssh/id_rsa.pub


### PR DESCRIPTION
Causes conflicts with part 0 from the manager playbook.

Related to 75fd285e3e904070aed6674b22f147fe51560bea.