### PR TITLE
terraform: retry on gateway timeout

### DIFF
--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -1,6 +1,7 @@
 retryable_errors = [
-    "(?s).*operation timed out.*",
-    "(?s).*The backend server is unreachable.*",
-    "(?s).*Quota exceeded for resources.*",
     "(?s).*Error waiting for instance.*",
+    "(?s).*Gateway Timeout.*",
+    "(?s).*Quota exceeded for resources.*",
+    "(?s).*The backend server is unreachable.*",
+    "(?s).*operation timed out.*",
 ]


### PR DESCRIPTION
This should avoid issues like this one:

Error: Error creating openstack_compute_volume_attach_v2 daf46c9b-e02d-478e-ba2b-b8327e729e1a: Gateway Timeout

  with openstack_compute_volume_attach_v2.node_volume_attachment[1],
  on default_custom.tf line 41, in resource "openstack_compute_volume_attach_v2" "node_volume_attachment":
  41: resource "openstack_compute_volume_attach_v2" "node_volume_attachment" {

time=2023-05-18T04:25:06Z level=error msg=Terraform invocation failed in /home/zuul-testbed-cleura01/src/github.com/osism/testbed/terraform time=2023-05-18T04:25:06Z level=error msg=1 error occurred:
	* exit status 1