### PR TITLE
Add Zuul CI jobs for deploying, updating and upgrading Ceph Quincy

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -157,16 +157,9 @@
     merge-mode: squash-merge
     check:
       jobs:
-        - ansible-lint
-        - yamllint
-        - flake8
-        - testbed-deploy
-        - testbed-deploy-ceph
-        - testbed-deploy-stable
-        - testbed-update-stable
-        - testbed-upgrade
-        - testbed-upgrade-ceph
-        - testbed-upgrade-stable
+        - testbed-deploy-ceph-quincy
+        - testbed-update-ceph-quincy
+        - testbed-upgrade-ceph-quincy
     gate:
       jobs:
         - ansible-lint

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -97,6 +97,33 @@
     run: playbooks/deploy-ceph.yml
 
 - job:
+    name: testbed-deploy-ceph-quincy
+    parent: testbed-deploy
+    vars:
+      ceph_version: quincy
+      ceph_image_version: 17.2.4
+      cephclient_version: 17.2.4
+    run: playbooks/deploy-ceph.yml
+
+- job:
+    name: testbed-update-ceph-quincy
+    parent: testbed-deploy-ceph-quincy
+    vars:
+      ceph_version: quincy
+      ceph_image_version: 17.2.6
+      cephclient_version: 17.2.6
+    run: playbooks/upgrade-ceph.yml
+
+- job:
+    name: testbed-upgrade-ceph-quincy
+    parent: testbed-deploy-ceph
+    vars:
+      ceph_version: quincy
+      ceph_image_version: 17.2.6
+      cephclient_version: 17.2.6
+    run: playbooks/upgrade-ceph.yml
+
+- job:
     name: testbed-deploy-cleura
     parent: testbed-deploy
     nodeset: testbed-orchestrator-cleura


### PR DESCRIPTION
Add Zuul CI jobs for deploying Ceph Quincy (with 17.2.4), updating Ceph Quincy (from 17.2.4 -> 17.2.6) and upgrading Ceph Quincy (from Pacific to 17.2.6).

Required for/Related to https://github.com/osism/issues/issues/533

