### PR TITLE
Added documentation of how to add an SSL cert to keycloak truststore

### DIFF
--- a/doc/federation.md
+++ b/doc/federation.md
@@ -9,12 +9,7 @@
 
 :::
 
-Open a login shell on the manager via SSH:
-
-```sh
-   make ssh ENVIRONMENT=regiocloud
-   make login ENVIRONMENT=regiocloud  # this is just an alias for "make ssh"
-```
+Open a login shell on the manager via SSH.
 
 Copy the SSL certificate to the keycloak container
 
@@ -26,7 +21,7 @@ Add the new certificate to the Keycloak internal truststore
 
 ```sh
    docker exec -ti -u root keycloak bash
-   keytool -cacerts -import -alias traefik -file /traefik.pem -storepass "changeit" -noprompt
+   keytool -cacerts -import -alias remoteCertificate -file /certificate.pem -storepass "changeit" -noprompt
 ```
 
 After that, Keycloak will be able to resolve the new SSL certificate without any problem.

--- a/doc/federation.md
+++ b/doc/federation.md
@@ -1,0 +1,32 @@
+# Federation in Keycloak
+
+## Adding remote SSL certificate to Keycloak truststore
+
+:::note
+
+>**note:**
+>The following commands are executed from the **manager** node in a working testbed.
+
+:::
+
+Open a login shell on the manager via SSH:
+
+```sh
+   make ssh ENVIRONMENT=regiocloud
+   make login ENVIRONMENT=regiocloud  # this is just an alias for "make ssh"
+```
+
+Copy the SSL certificate to the keycloak container
+
+```sh
+   docker cp cert.pem keycloak:/certificate.pem
+```
+
+Add the new certificate to the Keycloak internal truststore
+
+```sh
+   docker exec -ti -u root keycloak bash
+   keytool -cacerts -import -alias traefik -file /traefik.pem -storepass "changeit" -noprompt
+```
+
+After that, Keycloak will be able to resolve the new SSL certificate without any problem.


### PR DESCRIPTION
SCS is able to be federate out to external IdP (https://github.com/SovereignCloudStack/issues/issues/182)

As part of the issue I added a small documentation on how to add a remote SSL certificate to the Keycloak truststore to allow Keycloak to resolve that certificate.