### PR TITLE
Use the S256 method for PKCE as prescribed by RFC

### DIFF
--- a/environments/custom/playbook-keycloak-oidc-client-config.yml
+++ b/environments/custom/playbook-keycloak-oidc-client-config.yml
@@ -75,7 +75,7 @@
             --set directAccessGrantsEnabled=true
             --set publicClient=true
             --set secret="{{ keystone_container_federation_oidc_client_secret }}"
-            --set 'attributes."pkce.code.challenge.method"="plain"'
+            --set 'attributes."pkce.code.challenge.method"="S256"'
       when: keystone_client_id not in available_clients
       run_once: true
       no_log: true

--- a/environments/kolla/files/overlays/keystone/wsgi-keystone.conf
+++ b/environments/kolla/files/overlays/keystone/wsgi-keystone.conf
@@ -59,7 +59,7 @@ LogLevel info
 {% endif %}
     OIDCClaimPrefix "OIDC-"
     OIDCClaimDelimiter ","
-    OIDCPKCEMethod plain
+    OIDCPKCEMethod S256
     OIDCResponseType "{{ keystone_federation_oidc_response_type }}"
     OIDCScope "{{ keystone_federation_oidc_scopes }}"
 #   OIDCMetadataDir {{ keystone_container_federation_oidc_metadata_folder }}


### PR DESCRIPTION
[RFC  7636](https://datatracker.ietf.org/doc/html/rfc7636) says `If the client is capable of using "S256", it MUST use "S256"`. We have confirmed in the testbed that we can, so we should make this trivial switch.