### PR TITLE
Fix rally testing

### DIFF
--- a/contrib/rally/rally.json
+++ b/contrib/rally/rally.json
@@ -1,6 +1,6 @@
 {
     "openstack": {
-        "auth_url": "http://api.testbed.osism.xyz:5000/v3",
+        "auth_url": "https://api.testbed.osism.xyz:5000/v3",
         "region_name": "RegionOne",
         "endpoint_type": "public",
         "admin": {

--- a/contrib/rally/rally.sh
+++ b/contrib/rally/rally.sh
@@ -3,23 +3,17 @@
 sudo mkdir -p /opt/rally
 sudo chown dragon: /opt/rally
 
+echo Installing rally, this may take a couple of minutes
+
 INSTALL_LOG=/opt/rally/rally-install-$(date +%Y-%m-%d).log
 
-sudo apt-get install -y virtualenv >>$INSTALL_LOG 2>&1
+sudo apt-get install -y python3-venv >>$INSTALL_LOG 2>&1
 
-virtualenv -p python3 /opt/rally/.venv >>$INSTALL_LOG 2>&1
+python3 -m venv /opt/rally/.venv >>$INSTALL_LOG 2>&1
 source /opt/rally/.venv/bin/activate >>$INSTALL_LOG 2>&1
-pip3 install rally-openstack >>$INSTALL_LOG 2>&1
+pip install rally-openstack >>$INSTALL_LOG 2>&1
 
-# 2020-09-30 20:46:34.065 12177 WARNING rally.common.plugin.discover [-]        Failed to load plugins
-# from module 'rally_openstack' (package: 'rally-openstack 2.0.0'): (importlib-metadata 2.0.0
-# (/opt/rally/.venv/lib/python3.6/site-packages), Requirement.parse('importlib-metadata<2,>=0.12;
-# python_version < "3.8"'), {'virtualenv'}): pkg_resources.ContextualVersionConflict: (importlib-metadata
-# 2.0.0 (/opt/rally/.venv/lib/python3.6/site-packages), Requirement.parse('importlib-metadata<2,>=0.12;
-# python_version < "3.8"'), {'virtualenv'})
-# Platform openstack not found
-
-pip3 install "importlib-metadata<2,>=0.12" >>$INSTALL_LOG 2>&1
+echo Finished installing rally, starting tests
 
 rally --config-file /opt/configuration/contrib/rally/rally.conf db create || rally --config-file /opt/configuration/contrib/rally/rally.conf db upgrade
 rally --config-file /opt/configuration/contrib/rally/rally.conf env create --name osism --spec /opt/configuration/contrib/rally/rally.json 2>/dev/null >/dev/null || true


### PR DESCRIPTION
- Use https keystone URL
- Drop outdated workaround