### PR TITLE
logout redirect url issue

### DIFF
--- a/environments/custom/configuration.yml
+++ b/environments/custom/configuration.yml
@@ -19,9 +19,9 @@ keycloak_key_provider_component_name: "rsa-for-keystone"
 
 keystone_client_id: "keystone"
 keystone_redirect_uris:
-  - "https://api.testbed.osism.xyz:5000/redirect_uri/"
+  - "https://api.testbed.osism.xyz:5000/redirect_uri"
   - "https://api.testbed.osism.xyz"
-  - "https://192.168.16.254:5000/redirect_uri/"
+  - "https://192.168.16.254:5000/redirect_uri"
   - "https://192.168.16.254"
 
 keycloak_private_key_file_path: "{{ configuration_directory }}/environments/custom/files/keycloak/private_key.pem"

--- a/environments/custom/playbook-keycloak-oidc-client-config.yml
+++ b/environments/custom/playbook-keycloak-oidc-client-config.yml
@@ -79,10 +79,10 @@
             --set publicClient=true
             --set secret="{{ keystone_container_federation_oidc_client_secret }}"
             --set 'attributes."pkce.code.challenge.method"="S256"'
-            --set 'attributes."post.logout.redirect.uris"="https://api.testbed.osism.xyz/auth/logout/"'
+            --set 'attributes."post.logout.redirect.uris"="https://api.testbed.osism.xyz:5000/redirect_uri?logout=https://api.testbed.osism.xyz:5000/logout"'
             --set 'attributes."backchannel.logout.revoke.offline.tokens"="true"'
             --set 'attributes."backchannel.logout.session.required"="true"'
-            --set 'attributes."backchannel.logout.url"="https://api.testbed.osism.xyz:5000/redirect_uri/?logout=backchannel"'
+            --set 'attributes."backchannel.logout.url"="https://api.testbed.osism.xyz:5000/redirect_uri?logout=backchannel"'
       when: keystone_client_id not in available_clients
       run_once: true
       no_log: true

--- a/environments/custom/playbook-keycloak-oidc-client-config.yml
+++ b/environments/custom/playbook-keycloak-oidc-client-config.yml
@@ -210,3 +210,19 @@
             --new-password=password
       when: "'alice' not in available_users"
       changed_when: true
+
+
+    - name: Copy testbed cert to Keycloak container
+      ansible.builtin.command: >-
+        docker cp /opt/traefik/certificates/default.cert {{ keycloak_service_container_name }}:/traefik.cert
+      when: "'alice' not in available_users"
+      changed_when: true
+
+
+    - name: Keytool import traefik cert
+      ansible.builtin.command: >-
+        docker exec -u root {{ keycloak_service_container_name }} keytool 
+          -cacerts -importcert -alias traefik -file /traefik.cert
+          -storepass "changeit" -noprompt
+      when: "'alice' not in available_users"
+      changed_when: true

--- a/environments/kolla/files/overlays/keystone/wsgi-keystone.conf
+++ b/environments/kolla/files/overlays/keystone/wsgi-keystone.conf
@@ -71,13 +71,13 @@ LogLevel info
     OIDCOAuthVerifyCertFiles {{ keystone_federation_openid_certificate_key_ids | join(" ") }}
 {% endif %}
     OIDCCryptoPassphrase {{ keystone_federation_openid_crypto_password }}
-    OIDCRedirectURI {{ keystone_public_url }}/redirect_uri/
+    OIDCRedirectURI {{ keystone_public_url }}/redirect_uri
 {% if enable_memcached | bool %}
     OIDCCacheType memcache
     OIDCMemCacheServers "{% for host in groups['memcached'] %}{{ 'api' | kolla_address(host) | put_address_in_context('memcache') }}:{{ memcached_port }}{% if not loop.last %} {% endif %}{% endfor %}"
 {% endif %}
 
-    <Location ~ "/redirect_uri/">
+    <Location ~ "/redirect_uri">
       Require valid-user
       AuthType openid-connect
     </Location>


### PR DESCRIPTION
Quick fix to the LOGOUT found on a fresh deploy of the testbed.

Someone has to check if the copy of the certificate into the container and the adition to the keycloak keytool is done in the correct "ansible" way.