### PR TITLE
terraform: add support for volume types

### DIFF
--- a/terraform/customisations/default_custom.tf
+++ b/terraform/customisations/default_custom.tf
@@ -49,4 +49,5 @@ resource "openstack_blockstorage_volume_v3" "node_volume" {
   name              = "${var.prefix}-volume-${count.index}-node-${count.index % var.number_of_nodes}"
   size              = var.volume_size_storage
   availability_zone = var.volume_availability_zone
+  volume_type       = var.volume_type
 }

--- a/terraform/environments/ci.tfvars
+++ b/terraform/environments/ci.tfvars
@@ -7,6 +7,7 @@
 # override:nodes_boot_from_image
 flavor_manager            = "SCS-4V-8-50s"
 flavor_node               = "SCS-8V-32-100s"
+volume_type               = "ssd"
 image                     = "Ubuntu 22.04"
 image_node                = "Ubuntu 22.04"
 public                    = "public"

--- a/terraform/environments/regiocloud.tfvars
+++ b/terraform/environments/regiocloud.tfvars
@@ -7,6 +7,7 @@
 # override:nodes_boot_from_image
 flavor_manager            = "SCS-4V-8-50"
 flavor_node               = "SCS-8V-32-100"
+volume_type               = "ssd"
 image                     = "Ubuntu 22.04"
 image_node                = "Ubuntu 22.04"
 public                    = "public"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -37,6 +37,11 @@ variable "flavor_manager" {
   default = "SCS-4V:8:50"
 }
 
+variable "volume_type" {
+  type    = string
+  default = "__DEFAULT__"
+}
+
 variable "availability_zone" {
   type    = string
   default = "south-2"


### PR DESCRIPTION
With the volume_type variable it is possible to set the volume type of the volumes used for ceph. By default the __DEFAULT__ volume type is used.