### PR TITLE
Use label pipeline for deployment jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -149,6 +149,8 @@
         - ansible-lint
         - yamllint
         - flake8
+    label:
+      jobs:
         - testbed-deploy
         - testbed-deploy-ceph
         - testbed-deploy-stable


### PR DESCRIPTION
We want to run these jobs only after a core reviewer has looked at the PR and attached the "zuul" label.