### PR TITLE
zuul: use local storage for CI jobs

### DIFF
--- a/terraform/environments/ci.tfvars
+++ b/terraform/environments/ci.tfvars
@@ -1,12 +1,12 @@
 # customisation:access_floatingip
 # customisation:default
 # customisation:neutron_floatingip
-# override:manager_boot_from_volume
+# override:manager_boot_from_image
 # override:neutron_availability_zone_hints_network
 # override:neutron_availability_zone_hints_router
-# override:nodes_boot_from_volume
-flavor_manager            = "SCS-4V-8"
-flavor_node               = "SCS-8V-32"
+# override:nodes_boot_from_image
+flavor_manager            = "SCS-4V-8-50s"
+flavor_node               = "SCS-8V-32-100s"
 volume_type               = "ssd"
 image                     = "Ubuntu 22.04"
 image_node                = "Ubuntu 22.04"


### PR DESCRIPTION
This way we do not have unnecessary traffic on the NVMe SSD pool.