### PR TITLE
zuul: increase timeout to 6h

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -48,7 +48,7 @@
       - ^doc/.*$
     # NOTE(frickler): Default zuul maximum timeout is 3h, this needs to
     # be explictly bumped in the tenant configuration
-    timeout: 16200
+    timeout: 20000
     vars:
       terraform_blueprint: testbed-default
 


### PR DESCRIPTION
It sometimes happens that a lot of things run in parallel, which leads to delays. In addition, more services and tests have been added.