### PR TITLE
zuul: merge cleanup & post play

### DIFF
--- a/playbooks/post.yml
+++ b/playbooks/post.yml
@@ -7,3 +7,31 @@
 
   roles:
     - stage-output
+
+- name: Post cleanup play
+  hosts: all
+
+  vars:
+    basepath: "{{ ansible_user_dir }}/src/github.com/osism/testbed"
+
+  vars_files:
+    - vars/cloud_envs.yml
+
+  tasks:
+    - name: Set cloud_env fact (Zuul deployment)
+      ansible.builtin.set_fact:
+        cloud_env: "{{ cloud_envs[hostvars[groups['all'][0]]['nodepool']['label']] }}"
+      when: "'nodepool' in hostvars[groups['all'][0]]"
+
+    - name: Set cloud_env fact (local deployment)
+      ansible.builtin.set_fact:
+        cloud_env: "{{ testbed_environment | default('ci') }}"
+      when: "'nodepool' not in hostvars[groups['all'][0]]"
+
+    - name: Clean the cloud environment
+      ansible.builtin.shell:
+        cmd: |
+          OS_CLOUD={{ cloud_env }} ~/venv/bin/python3 cleanup.py
+        chdir: "{{ basepath }}/terraform/scripts"
+      failed_when: false
+      changed_when: true


### PR DESCRIPTION
For whatever reason, the cleanup-post play is not executed. Merge the cleanup play with the post play so that it is always cleaned up.