### PR TITLE
Use CephFS as filesystem for OpenStack Manila

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -81,7 +81,7 @@ octavia_network_type: tenant
 designate_ns_record: openstack.testbed.osism.xyz
 
 # manila
-enable_manila_backend_generic: "yes"
+enable_manila_backend_cephfs_native: "yes"
 
 # ironic
 ironic_dnsmasq_interface: "vxlan0"

--- a/environments/kolla/files/overlays/manila/ceph.conf
+++ b/environments/kolla/files/overlays/manila/ceph.conf
@@ -1,0 +1,6 @@
+[global]
+mon host = {% for host in groups['ceph-mon'] %}{{ hostvars[host]['monitor_address'] }}{% if not loop.last %},{% endif %}{% endfor %}
+
+public network = {{ ceph_public_network }}
+max open files = 131072
+fsid = {{ ceph_cluster_fsid }}

--- a/releasenotes/notes/manila-cephfs-28b94dbdb39289c0.yaml
+++ b/releasenotes/notes/manila-cephfs-28b94dbdb39289c0.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    CephFS is now used as the default file system for OpenStack Manila.


### PR DESCRIPTION
Part of osism/issues#142