### PR TITLE
kolla: remove enable_neutron_agent_ha parameter

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -67,8 +67,6 @@ neutron_plugin_agent: ovn
 neutron_ovn_availability_zones:
   - nova
 
-enable_neutron_agent_ha: "yes"
-
 # nova
 # NOTE: Disable the debugging logs for Libvirt as Libvirt writes a lot of logs
 #       that are not of interest.


### PR DESCRIPTION
Only required when working with the Neutron L3 agent.