### PR TITLE
Get manager images from osism.harbor.regio.digital

### DIFF
--- a/ansible/manager-part-1.yml
+++ b/ansible/manager-part-1.yml
@@ -5,7 +5,6 @@
 
   vars:
     ansible_ssh_user: dragon
-    docker_registry: quay.io
     operator_user: dragon
     repo_path: /home/ubuntu/src/github.com
     version_manager: latest
@@ -57,18 +56,6 @@
         cmd: MANAGER_VERSION={{ version_manager }} gilt overlay
       when: version_manager != "latest"
       changed_when: true
-
-    - name: Set container registries
-      ansible.builtin.command:  # noqa: command-instead-of-module
-        chdir: /opt/configuration
-        cmd: "sed -i 's#{{ item }}: .*#{{ item }}: {{ docker_registry }}#g' /opt/configuration/environments/configuration.yml"
-      changed_when: true
-      # docker_registry is not changed because the images are not provided by us
-      with_items:
-        - ceph_docker_registry
-        - docker_registry_ansible
-        - docker_registry_kolla
-        - docker_registry_netbox
 
     - name: Copy testbed crt
       become: true

--- a/ansible/manager-part-3.yml
+++ b/ansible/manager-part-3.yml
@@ -68,7 +68,7 @@
       community.docker.docker_image:
         name: "{{ item }}"
         source: pull
-      async: 600
+      async: 1200
       poll: 0
       loop: "{{ images }}"
       register: async_results
@@ -81,7 +81,8 @@
         loop_var: "async_result_item"
       register: async_poll_results
       until: async_poll_results.finished
-      retries: 30
+      retries: 120
+      delay: 10
 
 - name: Apply role traefik & netbox
   hosts: testbed-manager.testbed.osism.xyz

--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -17,11 +17,11 @@ docker_opts:
 ##########################
 # container registries
 
+ceph_docker_registry: quay.io
 docker_registry: index.docker.io
-docker_registry_ansible: quay.io
+docker_registry_ansible: osism.harbor.regio.digital
 docker_registry_kolla: quay.io
 docker_registry_netbox: quay.io
-ceph_docker_registry: quay.io
 
 ##########################
 # operator


### PR DESCRIPTION
quay.io is often slow or unreliable. We are starting to switch back to our own registry.