### PR TITLE
Revert "Do not pull images with docker-compose service (#1923)"

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -13,7 +13,6 @@ docker_version: "5:24.0.7"
 docker_user: "{{ operator_user }}"
 docker_opts:
   max-concurrent-downloads: 20
-docker_compose_pull: false
 
 ##########################
 # container registries

--- a/releasenotes/notes/do-not-pull-images-with-docker-compose-service-21067abc864e3fb3.yaml
+++ b/releasenotes/notes/do-not-pull-images-with-docker-compose-service-21067abc864e3fb3.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Do not pull images when starting or restarting a docker-compose service.
-    This prevents long running times when testing.


### PR DESCRIPTION
This reverts commit 468133c87c553904ac2b4fb4d4b54c58b10c858b.

Does not work at the moment because of a incorrectly implemented health check in some osism.services roles.