### PR TITLE
kolla: only use the active ceph-mgr service for the dashboard

### DIFF
--- a/environments/kolla/files/overlays/haproxy/services.d/haproxy.cfg
+++ b/environments/kolla/files/overlays/haproxy/services.d/haproxy.cfg
@@ -6,7 +6,7 @@
 
 listen ceph_dashboard
   option httpchk
-  http-check expect status 200,302
+  http-check expect status 200
   {{ "bind %s:%s %s"|e|format(kolla_internal_vip_address, 8140, internal_tls_bind_info)|trim() }}
 {% for host in groups['ceph-mgr'] %}
   server {{ hostvars[host]['ansible_facts']['hostname'] }} {{ hostvars[host]['monitor_address'] }}:7000 check inter 2000 rise 2 fall 5


### PR DESCRIPTION
Related to osism/issues#814