### PR TITLE
PUll images sequentially

### DIFF
--- a/environments/custom/playbook-pull-images.yml
+++ b/environments/custom/playbook-pull-images.yml
@@ -34,17 +34,3 @@
         INTERACTIVE: "false"
       loop: "{{ images }}"
       changed_when: true
-      async: 3600
-      poll: 0
-      register: async_results
-
-    - name: Check sync status
-      ansible.builtin.async_status:
-        jid: "{{ async_result_item.ansible_job_id }}"
-      loop: "{{ async_results.results }}"
-      loop_control:
-        loop_var: "async_result_item"
-      register: async_poll_results
-      until: async_poll_results.finished
-      delay: 10
-      retries: 360


### PR DESCRIPTION
This avoids problems with the newly introduced pass-through cache.