### PR TITLE
Do not deploy the openstack-health-monitor

### DIFF
--- a/environments/openstack/clouds.yml
+++ b/environments/openstack/clouds.yml
@@ -43,15 +43,6 @@ clouds:
       user_domain_name: default
     cacert: /etc/ssl/certs/ca-certificates.crt
     identity_api_version: 3
-  openstack_health_monitor:
-    auth:
-      username: test
-      project_name: test
-      auth_url: https://api.testbed.osism.xyz:5000/v3
-      project_domain_name: default
-      user_domain_name: default
-    cacert: /etc/ssl/certs/ca-certificates.crt
-    identity_api_version: 3
   refstack-0:
     auth:
       username: refstack-0

--- a/scripts/bootstrap/300-openstack-services.sh
+++ b/scripts/bootstrap/300-openstack-services.sh
@@ -19,5 +19,4 @@ fi
 
 if [[ "$REFSTACK" == "false" ]]; then
     osism apply --environment openstack test
-    osism apply openstack-health-monitor
 fi


### PR DESCRIPTION
The osism.services.openstack_health_monitor role is not functional at the moment.

The openstack health monitor can be debployed with https://github.com/SovereignCloudStack/openstack-health-monitor/tree/main/startup after the testbed deployment finished.