### PR TITLE
Deploy kubernetes/keycloak only as of 7.0.0c

### DIFF
--- a/scripts/deploy/200-infrastructure-services-basic.sh
+++ b/scripts/deploy/200-infrastructure-services-basic.sh
@@ -28,7 +28,7 @@ fi
 
 # In OSISM >= 7.0.0, the Keycloak deployment (technical preview) was switched from
 # Docker Compose to Kubernetes.
-if [[ $MANAGER_VERSION =~ ^7\.[0-9]\.[0-9][b-z]?$ || $MANAGER_VERSION == "latest" ]]; then
+if [[ $MANAGER_VERSION =~ ^7\.[0-9]\.[0-9][c-z]?$ || $MANAGER_VERSION == "latest" ]]; then
     osism apply keycloak
     osism apply keycloak-oidc-client-config
 else


### PR DESCRIPTION
7.0.0b will still contain various errors.

Related to 294af384a1944c2c5b15c090dd58db0c68c83688