### PR TITLE
Disable keystone federation by default

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -39,7 +39,7 @@ openstack_service_workers: 2
 openstack_logging_debug: "True"
 
 # keystone
-enable_keystone_federation: "yes"
+enable_keystone_federation: "no"
 keystone_oidc_forward_header: "X-Forwarded-Proto"
 keystone_enable_federation_openid: "yes"
 keystone_federation_oidc_response_type: "code"

--- a/scripts/deploy-identity-services.sh
+++ b/scripts/deploy-identity-services.sh
@@ -11,10 +11,14 @@ source /opt/manager-vars.sh
 
 osism apply openstackclient
 
-osism apply kubernetes
-
-osism apply keycloak
-osism apply keycloak-oidc-client-config
+# In OSISM >= 7.0.0, the Keycloak deployment (technical preview) was switched from
+# Docker Compose to Kubernetes.
+if [[ $MANAGER_VERSION =~ ^7\.[0-9]\.[0-9]$ || $MANAGER_VERSION == "latest" ]]; then
+    osism apply kubernetes
+    osism apply keycloak
+    osism apply keycloak-oidc-client-config
+    sed -i "s/enable_keystone_federation: \"no\"/enable_keystone_federation: \"yes\"/" /opt/configuration/environments/kolla/configuration.yml
+fi
 
 osism apply common
 osism apply loadbalancer

--- a/scripts/deploy/200-infrastructure-services-basic.sh
+++ b/scripts/deploy/200-infrastructure-services-basic.sh
@@ -28,9 +28,8 @@ fi
 
 # In OSISM >= 7.0.0, the Keycloak deployment (technical preview) was switched from
 # Docker Compose to Kubernetes.
-if [[ $MANAGER_VERSION =~ ^7\.[0-9]\.[0-9][c-z]?$ || $MANAGER_VERSION == "latest" ]]; then
+if [[ $MANAGER_VERSION =~ ^7\.[0-9]\.[0-9]$ || $MANAGER_VERSION == "latest" ]]; then
     osism apply keycloak
     osism apply keycloak-oidc-client-config
-else
-    sed -i "s/enable_keystone_federation: \"yes\"/enable_keystone_federation: \"no\"/" /opt/configuration/environments/kolla/configuration.yml
+    sed -i "s/enable_keystone_federation: \"no\"/enable_keystone_federation: \"yes\"/" /opt/configuration/environments/kolla/configuration.yml
 fi


### PR DESCRIPTION
Can only be used from OSISM 7.0.0 onwards.