### PR TITLE
ceph: remove osds_per_device parameter

### DIFF
--- a/environments/ceph/configuration.yml
+++ b/environments/ceph/configuration.yml
@@ -16,10 +16,6 @@ enable_ceph_rgw: true
 
 dmcrypt: true
 
-# NOTE: It is common to place more than 1 OSD on flash devices. To simulate
-#       upgrades etc. with this approach this is also used here.
-osds_per_device: 2
-
 ##########################
 # network
 


### PR DESCRIPTION
No longer needed as we prepare the OSDs with our own plays.