### PR TITLE
Use `xdg-open` on linux

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -42,6 +42,12 @@ ifneq (,$(wildcard ./backend.env))
   include backend.env
 endif
 
+ifeq ($(shell uname -s), Linux)
+  OPEN_CMD := xdg-open
+else
+  OPEN_CMD := open
+endif
+
 reset:
 	@rm -rf .terraform/providers
 
@@ -168,7 +174,7 @@ vpn-wireguard: .MANAGER_ADDRESS.$(ENVIRONMENT) .id_rsa.$(ENVIRONMENT)
 	scp -o StrictHostKeyChecking=no -i .id_rsa.$(ENVIRONMENT) $(PARAMS) $(USERNAME)@$$MANAGER_ADDRESS:/home/dragon/wireguard-client.conf $(PWD)/wg-$(ENVIRONMENT).conf
 	sudo wg-quick down $(PWD)/wg-$(ENVIRONMENT).conf || true
 	sudo wg-quick up $(PWD)/wg-$(ENVIRONMENT).conf
-	@open "https://osism.github.io/docs/guides/other-guides/testbed#webinterfaces"
+	@$(OPEN_CMD) "https://osism.github.io/docs/guides/other-guides/testbed#webinterfaces"
 	@read -p "STOP?" CONT
 	sudo wg-quick down $(PWD)/wg-$(ENVIRONMENT).conf
 


### PR DESCRIPTION
The `terraform/Makefile` uses the `open` command to show the documentation of OSISM service endpoints. On linux the equivalent command would be `xdg-open`.