### PR TITLE
fix check-local-versions.yml

### DIFF
--- a/ansible/check-local-versions.yml
+++ b/ansible/check-local-versions.yml
@@ -13,7 +13,7 @@
     - name: Get terraform version
       ansible.builtin.shell: >-
         set -o pipefail &&
-        tofu --version | head -n1 | awk '{print $2}' | awk -Fv '{print $2}'
+        tofu version | head -n1 | awk '{print $2}' | awk -Fv '{print $2}'
       register: result
       changed_when: false
       args:


### PR DESCRIPTION
got a Error in a gitlab CI Pipeline, because the command tofu --version fails.
And to fix it the characters "--" must be removed.