### PR TITLE
When doing an upgrade deploy magnum if magnum is not yet there

### DIFF
--- a/scripts/upgrade/300-openstack-services-basic.sh
+++ b/scripts/upgrade/300-openstack-services-basic.sh
@@ -25,5 +25,13 @@ fi
 osism apply -a upgrade octavia
 
 if [[ $MANAGER_VERSION =~ ^7\.[0-9]\.[0-9][a-z]?$ || $MANAGER_VERSION == "latest" ]]; then
-    osism apply -a upgrade magnum
+    # In the testbed, the service was only added with OSISM 7.0.0. It is therefore necessary
+    # to check in advance whether the service is already available. If not, a deployment must
+    # be carried out instead of an upgrade.
+
+    if [[ -z $(openstack --os-cloud admin service list -f value -c Name | grep magnum) ]]; then
+        osism apply magnum
+    else
+        osism apply -a upgrade magnum
+    fi
 fi


### PR DESCRIPTION
In the testbed, the service was only added with OSISM 7.0.0. It is therefore necessary to check in advance whether the service is already available. If not, a deployment must be carried out instead of an upgrade.