### PR TITLE
ceph: decrease default num of pgs per pool to 32

### DIFF
--- a/environments/ceph/configuration.yml
+++ b/environments/ceph/configuration.yml
@@ -15,7 +15,7 @@ enable_ceph_rgw: true
 # osd
 
 dmcrypt: true
-mon_max_pg_per_osd: 512
+openstack_pool_default_pg_num: 32
 
 ##########################
 # network


### PR DESCRIPTION
We only have a limited number of OSDs. Therefore, increase the number of PGs per OSD in the testbed.

Error ERANGE:  pg_num 64 size 3 for this pool would result in 275 cumulative PGs per OSD (1650 total PG replicas on 6 'in' root OSDs by crush rule) which exceeds the mon_max_pg_per_osd value of 250

This also reverts a5f70f8cb48d4b4ccf0798690d3de8a33776595c