### PR TITLE
Increase python3.10 version requirement to due 'ansible' package

### DIFF
--- a/ansible/check-local-versions.yml
+++ b/ansible/check-local-versions.yml
@@ -33,7 +33,7 @@
       args:
         executable: /bin/bash
 
-    - name: Fail if python version is lower than 3.8.0
+    - name: Fail if python version is lower than 3.10.0
       ansible.builtin.fail:
         msg: "Python version is {{ result.stdout }}, see https://osism.tech/docs/guides/other-guides/testbed/ for required version."
-      when: result.stdout is ansible.builtin.version('3.8.0', '<')
+      when: result.stdout is ansible.builtin.version('3.10.0', '<')


### PR DESCRIPTION
ansible pip package with version 9.4.0 is installed in requirements.txt, but it is only compatible with python >= 3.10 (https://pypi.org/project/ansible/)