### PR TITLE
replace head cmd in pipeline with sed - Signed-off-by: eduard.herlitz…

### DIFF
--- a/ansible/check-local-versions.yml
+++ b/ansible/check-local-versions.yml
@@ -18,7 +18,7 @@
     - name: Get terraform version
       ansible.builtin.shell: >-
         set -o pipefail &&
-        tofu --version | head -n1 | awk '{print $2}' | awk -Fv '{print $2}'
+        tofu version | sed -n 1p | awk '{print $2}' | awk -Fv '{print $2}'
       register: result
       changed_when: false
       args:


### PR DESCRIPTION
replace head cmd in pipeline with sed, because head fails sometimes with exit code 141. Fix tofu version check.