### PR TITLE
Rename regiocloud-fast in clouds-public.yaml

### DIFF
--- a/terraform/clouds-public.yaml
+++ b/terraform/clouds-public.yaml
@@ -7,7 +7,7 @@ public-clouds:
       - name: RegionA
     identity_api_version: 3
     block_storage_api_version: 3
-  regiocloud-fast:
+  regio-fast:
     auth:
       auth_url: https://keystone.services.a.regiocloud.tech/v3
     regions:


### PR DESCRIPTION
The environment `regiocloud-fast` was renamed to `regio-fast`. The profile in `terraform/clouds-public.yaml` needs to be changed aswell.