### PR TITLE
Increase MTU of public network inside testbed

### DIFF
--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -50,7 +50,7 @@
         external: true
         provider_network_type: flat
         provider_physical_network: physnet1
-        mtu: 1300  # NOTE: necessary because Geneve/VxLAN in Geneve/VxLAN
+        mtu: 1350  # NOTE: necessary because VxLAN in Geneve/VxLAN
 
     - name: Create public subnet
       openstack.cloud.subnet:

--- a/environments/openstack/playbook-test.yml
+++ b/environments/openstack/playbook-test.yml
@@ -68,7 +68,7 @@
         cloud: test
         state: present
         name: test
-        mtu: 1300  # NOTE: necessary because Geneve/VxLAN in Geneve/VxLAN
+        mtu: 1350  # NOTE: necessary because VxLAN in Geneve/VxLAN
 
     - name: Create test subnet
       openstack.cloud.subnet:


### PR DESCRIPTION
The `terraform-base` currently creates a network with an MTU of 1400 bytes. The external network is a VXLAN on that network. VXLANs on IPv4 networks have an overhead of
20 bytes IPv4 header + 8 bytes UDP header + 8 bytes VXLAN header + 14 bytes MAC thus leaving 1350 bytes.
The self-service network has a maximum MTU of 1400 bytes minus the geneve overhead of
20 bytes IPv4 header + 8 bytes UDP header + 16 bytes Geneve header + 14 bytes MAC thus leaving 1342 bytes.
In order to access an instance using the maximum MTU via an attached floating IP as in tempest test
`tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_mtu_sized_frames` the MTU of the floating IP network needs to be greater or equal to the MTU of the self-service network.
Since there is enough free space the created floating IP network's MTU is increased to 1350 bytes.

Note that when the VXLAN of the external network and the self-service networks are encapsulated in IPv6 networks these values need to be adapted, because of IPv6's increased header size of 40 bytes.