### PR TITLE
Pin docker_cli_version

### DIFF
--- a/ansible/manager-part-2.yml
+++ b/ansible/manager-part-2.yml
@@ -12,6 +12,7 @@
     docker_storage_driver: overlay2
     docker_user: dragon
     docker_version: "5:24.0.9"
+    docker_cli_version: "5:24.0.9"
     docker_opts:
       max-concurrent-downloads: 20
     docker_insecure_registries:

--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -10,6 +10,8 @@ testbed_mtu_node: "{{ testbed_mtu }}"
 # docker
 
 docker_version: "5:24.0.9"
+docker_cli_version: "5:24.0.9"
+
 docker_user: "{{ operator_user }}"
 docker_opts:
   max-concurrent-downloads: 20


### PR DESCRIPTION
The Docker CLI version must also be pinned as the default of the Docker CLI version was only recently set to the Docker version itself. If the Docker CLI version has not been pinned, problems may occur if only the Docker CLI is downgraded/upgraded after the initial deployment of Docker.