### PR TITLE
Improve haproxy and ceph dashboard integration

### DIFF
--- a/environments/ceph/configuration.yml
+++ b/environments/ceph/configuration.yml
@@ -29,6 +29,12 @@ cluster_network: 192.168.16.0/20
 openstack_config: true
 
 ##########################
+# dashboard
+
+ceph_dashboard_standby_behaviour: error
+ceph_dashboard_standby_error_status_code: 404
+
+##########################
 # custom
 
 ceph_conf_overrides:

--- a/environments/kolla/files/overlays/haproxy/services.d/haproxy.cfg
+++ b/environments/kolla/files/overlays/haproxy/services.d/haproxy.cfg
@@ -10,7 +10,8 @@
 
 listen ceph_dashboard
   option httpchk
-  http-check expect status 200
+  http-check expect status 200,404
+  http-check disable-on-404
   {{ "bind %s:%s %s"|e|format(kolla_internal_vip_address, 8140, internal_tls_bind_info)|trim() }}
 {% for host in groups['ceph-mgr'] %}
   server {{ hostvars[host]['ansible_facts']['hostname'] }} {{ hostvars[host]['monitor_address'] }}:7000 check inter 2000 rise 2 fall 5


### PR DESCRIPTION
Passive ceph mgr are configured to emit an error with status code 404 for ceph dashboard.
Haproxy is configured to treat status 404 as server state "NOLB" instead of marking servers as "DOWN".
The clear separation between a passive server with state "NOLB" and a malfunctioning server with state "DOWN" will allow more differentiated alerting on haproxy server states.

Part of https://github.com/osism/issues/issues/1013