### PR TITLE
Make linux-generic-hwe independent of the Ubuntu version used

### DIFF
--- a/ansible/manager-part-0.yml
+++ b/ansible/manager-part-0.yml
@@ -43,7 +43,9 @@
       become: true
       ansible.builtin.apt:
         name:
-          - linux-generic-hwe-22.04
+          # The correct package name is linux-generic-hwe-22.04 on Ubuntu 22.04
+          # and linux-generic-hwe-24.04 on Ubuntu 24.04.
+          - "linux-generic-hwe-{{ ansible_distribution_version }}"
           - python3-netaddr
           - python3-pip
         update_cache: true

--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -63,7 +63,9 @@ cleanup_packages_extra:
   - snapd
 
 required_packages_extra:
-  - linux-generic-hwe-22.04
+  # The correct package name is linux-generic-hwe-22.04 on Ubuntu 22.04
+  # and linux-generic-hwe-24.04 on Ubuntu 24.04.
+  - "linux-generic-hwe-{{ ansible_distribution_version }}"
 
 ##########################
 # serial


### PR DESCRIPTION
The correct package name is linux-generic-hwe-22.04 on Ubuntu 22.04 and linux-generic-hwe-24.04 on Ubuntu 24.04.