### PR TITLE
ansible-lint: do not mock kubernetes.core.k8s

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,8 +15,6 @@ exclude_paths:
 mock_roles:
   - manager
   - stage-output
-mock_modules:
-  - kubernetes.core.k8s
 use_default_rules: true
 rulesdir:
   - ./.ansible-lint-rules/


### PR DESCRIPTION
Not longer required.