### PR TITLE
Pin requests for initial manager service deployment

### DIFF
--- a/ansible/manager-part-0.yml
+++ b/ansible/manager-part-0.yml
@@ -74,6 +74,14 @@
         virtualenv: "{{ venv_path }}"
         virtualenv_command: python3 -m venv
 
+    - name: Install requests < 2.32.0
+      ansible.builtin.pip:
+        umask: "0022"
+        name: "requests<2.32.0"
+        state: present
+        virtualenv: "{{ venv_path }}"
+        virtualenv_command: python3 -m venv
+
     - name: Create directories in /opt/src
       become: true
       ansible.builtin.file:


### PR DESCRIPTION
Can be reverted when the "Error while fetching server API version: Not supported URL scheme http+docker" is fixed in requests. There are just various releases of requests that were yanked one after the other.