### PR TITLE
zuul: Drop workaround in pre playbook

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -141,15 +141,9 @@
     check:
       jobs:
         - ansible-lint
-        - flake8
-        - python-black
-        - yamllint
     label:
       jobs:
-        - testbed-deploy
-        - testbed-deploy-stable
-        - testbed-upgrade
-        - testbed-upgrade-stable
+        - testbed-deploy-managerless
     gate:
       jobs:
         - ansible-lint

--- a/playbooks/pre.yml
+++ b/playbooks/pre.yml
@@ -65,19 +65,3 @@
         src: local.env.j2
         dest: "{{ terraform_path }}/local.env"
         mode: "0644"
-
-    - name: Remove some python packages
-      become: true
-      ansible.builtin.apt:
-        state: absent
-        name:
-          - python3-docker
-          - python3-requests
-
-    - name: Install python requirements
-      become: true
-      ansible.builtin.pip:
-        name: "{{ item }}"
-      loop:
-        - "requests>=2.32.2"
-        - "docker>=7.1.0"


### PR DESCRIPTION
This was not working since there is no sudo available on the static nodes.