### PR TITLE
Prepare dedicated identity testbed for Keystone/Keycloak integration

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -46,22 +46,7 @@ opensearch_hard_retention_period_days: 1
 
 # keystone
 enable_keystone_federation: "no"
-keystone_oidc_forward_header: "X-Forwarded-Proto"
-keystone_enable_federation_openid: "yes"
-keystone_federation_oidc_response_type: "code"
-keystone_identity_providers:
-  - name: "keycloak"
-    openstack_domain: "keycloak"
-    protocol: "openid"
-    identifier: "https://keycloak.testbed.osism.xyz/auth/realms/osism"
-    public_name: "Authenticate via Keycloak"
-    attribute_mapping: "mappingId1"
-    metadata_folder: "{{ node_custom_config }}/keystone/federation/oidc/metadata"
-keystone_identity_mappings:
-  - name: "mappingId1"
-    file: "{{ node_custom_config }}/keystone/federation/oidc/attribute_maps/oidc_attribute_mappingId1.json"
-# Keystone auth endpoint
-keystone_logout_url: "https://api.testbed.osism.xyz/auth/"
+keystone_enable_federation_openid: "no"
 
 # libvirt
 # NOTE: Doesn't work yet with our setup

--- a/environments/kolla/group_vars/keystone.yml
+++ b/environments/kolla/group_vars/keystone.yml
@@ -1,0 +1,16 @@
+---
+keystone_oidc_forward_header: "X-Forwarded-Proto"
+keystone_federation_oidc_response_type: "code"
+keystone_identity_providers:
+  - name: "keycloak"
+    openstack_domain: "keycloak"
+    protocol: "openid"
+    identifier: "https://keycloak.testbed.osism.xyz/auth/realms/osism"
+    public_name: "Authenticate via Keycloak"
+    attribute_mapping: "mappingId1"
+    metadata_folder: "{{ node_custom_config }}/keystone/federation/oidc/metadata"
+keystone_identity_mappings:
+  - name: "mappingId1"
+    file: "{{ node_custom_config }}/keystone/federation/oidc/attribute_maps/oidc_attribute_mappingId1.json"
+# Keystone auth endpoint
+keystone_logout_url: "https://api.testbed.osism.xyz/auth/"

--- a/scripts/deploy-identity-services.sh
+++ b/scripts/deploy-identity-services.sh
@@ -11,14 +11,12 @@ source /opt/manager-vars.sh
 
 osism apply openstackclient
 
-# In OSISM >= 7.0.0, the Keycloak deployment (technical preview) was switched from
-# Docker Compose to Kubernetes.
-if [[ $MANAGER_VERSION =~ ^7\.[0-9]\.[0-9]$ || $MANAGER_VERSION == "latest" ]]; then
-    osism apply kubernetes
-    osism apply keycloak
-    osism apply keycloak-oidc-client-config
-    sed -i "s/enable_keystone_federation: \"no\"/enable_keystone_federation: \"yes\"/" /opt/configuration/environments/kolla/configuration.yml
-fi
+osism apply kubernetes
+osism apply keycloak
+osism apply keycloak-oidc-client-config
+
+sed -i "s/enable_keystone_federation: \"no\"/enable_keystone_federation: \"yes\"/" /opt/configuration/environments/kolla/configuration.yml
+sed -i "s/keystone_enable_federation_openid: \"no\"/keystone_enable_federation_openid: \"yes\"/" /opt/configuration/environments/kolla/configuration.yml
 
 osism apply common
 osism apply loadbalancer

--- a/scripts/deploy/200-infrastructure-services-basic.sh
+++ b/scripts/deploy/200-infrastructure-services-basic.sh
@@ -25,12 +25,3 @@ if [[ $MANAGER_VERSION =~ ^4\.[0-9]\.[0-9]$ || $OPENSTACK_VERSION == "yoga" ]]; 
 else
     osism apply opensearch
 fi
-
-# In OSISM >= 7.0.0, the Keycloak deployment (technical preview) was switched from
-# Docker Compose to Kubernetes. When using the External API customisation, the Keycloak
-# service and the Keystone federation are currently not used.
-if [[ ($MANAGER_VERSION =~ ^7\.[0-9]\.[0-9]$ || $MANAGER_VERSION == "latest") && "$EXTERNAL_API" == "false" ]]; then
-    osism apply keycloak
-    osism apply keycloak-oidc-client-config
-    sed -i "s/enable_keystone_federation: \"no\"/enable_keystone_federation: \"yes\"/" /opt/configuration/environments/kolla/configuration.yml
-fi

--- a/scripts/deploy/300-openstack-services-basic.sh
+++ b/scripts/deploy/300-openstack-services-basic.sh
@@ -6,6 +6,10 @@ source /opt/configuration/scripts/include.sh
 MANAGER_VERSION=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version"}}' osism-ansible)
 OPENSTACK_VERSION=$(docker inspect --format '{{ index .Config.Labels "de.osism.release.openstack"}}' kolla-ansible)
 
+# Do not use the Keystone/Keycloak integration by default. We only use this integration
+# in a special identity testbed.
+rm -f /opt/configuration/environments/kolla/group_vars/keystone.yml
+
 osism apply keystone
 osism apply placement
 osism apply neutron

--- a/scripts/upgrade/300-openstack-services-basic.sh
+++ b/scripts/upgrade/300-openstack-services-basic.sh
@@ -6,6 +6,10 @@ source /opt/configuration/scripts/include.sh
 
 MANAGER_VERSION=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version"}}' osism-ansible)
 
+# Do not use the Keystone/Keycloak integration by default. We only use this integration
+# in a special identity testbed.
+rm -f /opt/configuration/environments/kolla/group_vars/keystone.yml
+
 osism apply -a upgrade keystone
 osism apply -a upgrade placement
 osism apply -a upgrade neutron


### PR DESCRIPTION
The Keycloak OIDC client play and the SCS keycloak image are currently not working reliably. We are therefore moving this part to a dedicated testbed so that the general testbed deployment works independently.