### PR TITLE
Add ansible_facts replacement to URL of Ubuntu image

### DIFF
--- a/environments/openstack/playbook-bootstrap-images.yml
+++ b/environments/openstack/playbook-bootstrap-images.yml
@@ -6,7 +6,7 @@
   connection: local
 
   vars:
-    url_ubuntu_image: https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img
+    url_ubuntu_image: "https://cloud-images.ubuntu.com/minimal/releases/{{ ansible_distribution_release }}/release/ubuntu-{{ ansible_distribution_version }}-minimal-cloudimg-amd64.img"
     url_cirros_image: https://github.com/cirros-dev/cirros/releases/download/0.6.0/cirros-0.6.0-x86_64-disk.img
 
   tasks:
@@ -31,7 +31,7 @@
           distro: ubuntu
           hw_rng_model: virtio
 
-    - name: Download ubuntu minimal 22.04 image
+    - name: Download ubuntu minimal image
       ansible.builtin.get_url:
         url: "{{ url_ubuntu_image }}"
         dest: /tmp/ubuntu.img
@@ -42,11 +42,11 @@
       register: date
       changed_when: false
 
-    - name: Upload ubuntu minimal 22.04 image
+    - name: Upload ubuntu minimal image
       openstack.cloud.image:
         cloud: admin
         state: present
-        name: "Ubuntu 22.04"
+        name: "Ubuntu {{ ansible_distribution_version }}"
         is_public: true
         container_format: bare
         disk_format: qcow2
@@ -67,6 +67,6 @@
           image_original_user: ubuntu
           image_source: "{{ url_ubuntu_image }}"
           os_distro: ubuntu
-          os_version: "22.04"
+          os_version: "{{ ansible_distribution_version }}"
           replace_frequency: never
           uuid_validity: forever


### PR DESCRIPTION
Use the ansible_ facts to always upload the image that matches the distribution.
