### PR TITLE
Fix "Use insecure glance configuration" task

### DIFF
--- a/ansible/manager-part-3.yml
+++ b/ansible/manager-part-3.yml
@@ -107,12 +107,13 @@
     # paraemters in production is not recommended. Further details in OSSN-0090.
     # https://wiki.openstack.org/wiki/OSSN/OSSN-0090
     - name: Use insecure glance configuration
-      ansible.builtin.copy:
-        dest: /opt/configuration/environments/kolla/files/overlays/glance/glance-api.conf
-        content: |
+      ansible.builtin.blockinfile:
+        path: /opt/configuration/environments/kolla/files/overlays/glance/glance-api.conf
+        block: |
           [DEFAULT]
           show_image_direct_url = True
           show_multiple_locations = True
+        prepend_newline: true
         owner: dragon
         group: dragon
         mode: 0644


### PR DESCRIPTION
The "Use insecure glance configuration" task should not overwrite the existing glance-api.conf file. It should only add additional configuration to the existing glance-api.conf file.