### PR TITLE
Make it possible to overwrite the used cloud environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 export LC_ALL = C.UTF-8
 
 CONFIGURATION ?= main
+
 ENVIRONMENT ?= the_environment
+CLOUD_ENVIRONMENT ?= $(ENVIRONMENT)
 
 IMAGE_USERNAME ?= ubuntu
 
@@ -43,6 +45,7 @@ create: prepare ## Create required infrastructure with OpenTofu.
 	@contrib/setup-testbed.py --environment_check $(ENVIRONMENT)
 	make -C terraform \
 	  CEPH_STACK=$(CEPH_STACK) \
+	  CLOUD_ENVIRONMENT=$(CLOUD_ENVIRONMENT) \
 	  CONFIGURATION=$(CONFIGURATION) \
 	  ENVIRONMENT=$(ENVIRONMENT) \
 	  IMAGE_USERNAME=$(IMAGE_USERNAME) \

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -3,6 +3,7 @@ export LC_ALL = C.UTF-8
 CONFIGURATION = main
 CONSOLE = manager
 ENVIRONMENT ?= regiocloud
+CLOUD_ENVIRONMENT ?= $(ENVIRONMENT)
 USERNAME = dragon
 IMAGE_USERNAME = ubuntu
 
@@ -33,9 +34,9 @@ ifneq (,$(wildcard ./local.env))
   include local.env
 endif
 
-export OS_CLOUD ?= $(ENVIRONMENT)
+export OS_CLOUD ?= $(CLOUD_ENVIRONMENT)
 
-export TF_VAR_cloud_provider=$(ENVIRONMENT)
+export TF_VAR_cloud_provider=$(CLOUD_ENVIRONMENT)
 ifneq (,$(wildcard terraformrc))
   export TF_CLI_CONFIG_FILE ?= terraformrc
 endif


### PR DESCRIPTION
With the name Makefile parameter CLOUD_ENVIRONMENT it is possible to overwrite the used cloud profile. By default ENVIRONMENT is used.