### PR TITLE
Avoid deleting attached FIPs, better port filtering.

### DIFF
--- a/terraform/scripts/cleanup.py
+++ b/terraform/scripts/cleanup.py
@@ -165,14 +165,12 @@ def cleanup_floating_ips(conn, prefix):
 
 def main():
     PREFIX = os.environ.get("PREFIX", "testbed")
-    try:
-        OSENV = os.environ["OS_CLOUD"]
-    except KeyError:
-        try:
-            OSENV = os.environ["ENVIRONMENT"]
-        except KeyError as e:
+    OSENV = os.environ.get["OS_CLOUD"]
+    if not OSENV:
+        OSENV = os.environ.get["ENVIRONMENT"]
+        if not OSENV:
             logging.error("Need to have OS_CLOUD or ENVIRONMENT set!")
-            raise e
+            raise KeyError("Lacking both OS_CLOUD and ENVIRONMENT")
     conn = openstack.connect(cloud=OSENV)
     cleanup_servers(conn, PREFIX)
     cleanup_keypairs(conn, PREFIX)

--- a/terraform/scripts/cleanup.py
+++ b/terraform/scripts/cleanup.py
@@ -191,8 +191,10 @@ def main():
     PREFIX = os.environ.get("PREFIX", "testbed")
     OSENV = os.environ.get("OS_CLOUD") or os.environ.get("ENVIRONMENT")
     if not OSENV:
-            logging.error("Need to have OS_CLOUD or ENVIRONMENT set!")
-            raise KeyError("Lacking both OS_CLOUD and ENVIRONMENT")
+        logging.error("Need to have OS_CLOUD or ENVIRONMENT set!")
+        raise KeyError("Lacking both OS_CLOUD and ENVIRONMENT")
+    # You can pass a comma-separated list of strings to filter IP addrs
+    # for ports to be deleted
     portfilter_str = os.environ.get("IPADDR")
     PORTFILTER = portfilter_str.split(",") if portfilter_str else None
     conn = openstack.connect(cloud=OSENV)

--- a/terraform/scripts/cleanup.py
+++ b/terraform/scripts/cleanup.py
@@ -189,10 +189,8 @@ def cleanup_floating_ips(conn, prefix):
 
 def main():
     PREFIX = os.environ.get("PREFIX", "testbed")
-    OSENV = os.environ.get["OS_CLOUD"]
+    OSENV = os.environ.get("OS_CLOUD") or os.environ.get("ENVIRONMENT")
     if not OSENV:
-        OSENV = os.environ.get["ENVIRONMENT"]
-        if not OSENV:
             logging.error("Need to have OS_CLOUD or ENVIRONMENT set!")
             raise KeyError("Lacking both OS_CLOUD and ENVIRONMENT")
     PORTFILTER = os.environ.get("IPADDR").split(",")

--- a/terraform/scripts/cleanup.py
+++ b/terraform/scripts/cleanup.py
@@ -193,7 +193,8 @@ def main():
     if not OSENV:
             logging.error("Need to have OS_CLOUD or ENVIRONMENT set!")
             raise KeyError("Lacking both OS_CLOUD and ENVIRONMENT")
-    PORTFILTER = os.environ.get("IPADDR").split(",")
+    portfilter_str = os.environ.get("IPADDR")
+    PORTFILTER = portfilter_str.split(",") if portfilter_str else None
     conn = openstack.connect(cloud=OSENV)
     cleanup_servers(conn, PREFIX)
     cleanup_keypairs(conn, PREFIX)

--- a/terraform/scripts/cleanup.py
+++ b/terraform/scripts/cleanup.py
@@ -68,11 +68,11 @@ def cleanup_subnets(conn, prefix):
 
 def port_filter(port, prefix, ipfilter):
     """Determine whether port is to be cleaned up:
-       - If it is connected to a VM/LB/...: False
-       - It it has a name that starts with the prefix: True
-       - If it has a name not matching the prefix filter: False
-       - If it has no name and we do not have IP range filters: True
-       - Otherwise see if one of the specified IP ranges matches
+    - If it is connected to a VM/LB/...: False
+    - It it has a name that starts with the prefix: True
+    - If it has a name not matching the prefix filter: False
+    - If it has no name and we do not have IP range filters: True
+    - Otherwise see if one of the specified IP ranges matches
     """
     if port.device_owner:
         return False

--- a/terraform/scripts/cleanup.py
+++ b/terraform/scripts/cleanup.py
@@ -86,7 +86,7 @@ def port_filter(port, prefix, ipfilter):
         ip_addr = fixed_addr["ip_address"]
         for ipmatch in ipfilter:
             if ip_addr.startswith(ipmatch):
-                logger.debug(f"{ip_addr} matches {ipmatch}")
+                logging.debug(f"{ip_addr} matches {ipmatch}")
                 return True
     return False
 


### PR DESCRIPTION
Avoid deleting attached FIPs, better port filtering.

The filter in the search_floating_ip() statement does not do what it is
supposed to. Instead skip if there is a fixed_ip_address.

For port cleanup, provide better logic:
* Delete port unconditionally if it's name matches the prefix
* Keep it unconditionally if it has a name that does not match
* IF we have a list of IPADDR strings the beginning of the ip
addresses will be matched against the IPADDR strings; delete
if there is a match, do not delete if there is no match.
Always match, if no IPADDR filter is passed.

The filtering can be used to ensure we only delete IP addresses from
IP ranges in subnets that we have created. This improves coexistence
with other infrastructure in the smae project.
(If you can, avoid coexistence, though.)

This is a port from
https://github.com/SovereignCloudStack/standards/pull/712

This should fix https://github.com/osism/issues/issues/960
