### PR TITLE
infrastructure: do not enable extra plugins

### DIFF
--- a/environments/infrastructure/configuration.yml
+++ b/environments/infrastructure/configuration.yml
@@ -44,8 +44,6 @@ keycloak_host: keycloak.testbed.osism.xyz
 
 netbox_traefik: true
 netbox_host: netbox.testbed.osism.xyz
-netbox_plugins_extra:
-  - netbox_bgp
 
 ##########################
 # phpmyadmin


### PR DESCRIPTION
Sometimes they are not yet compatible with latest. In the testbed we should only use plugins that also worked in the CI of the netbox role.