### PR TITLE
disable verify_ca for magnum related openstack apis

### DIFF
--- a/environments/kolla/files/overlays/magnum.conf
+++ b/environments/kolla/files/overlays/magnum.conf
@@ -1,13 +1,16 @@
 [capi_client]
-verify_ca = false
+region_name = RegionOne
+endpoint_type = internalURL
+ca_file = /etc/ssl/certs/ca-certificates.crt
 
 [manila_client]
-verify_ca = false
+region_name = RegionOne
+endpoint_type = internalURL
+ca_file = /etc/ssl/certs/ca-certificates.crt
 
 [drivers]
 verify_ca = false
 
-
 [cluster_template]
-kubernetes_allowed_network_drivers = calico
-kubernetes_default_network_driver = calico
+kubernetes_allowed_network_drivers = cilium
+kubernetes_default_network_driver = cilium

--- a/environments/kolla/files/overlays/magnum.conf
+++ b/environments/kolla/files/overlays/magnum.conf
@@ -1,3 +1,13 @@
+[capi_client]
+verify_ca = false
+
+[manila_client]
+verify_ca = false
+
+[drivers]
+verify_ca = false
+
+
 [cluster_template]
 kubernetes_allowed_network_drivers = calico
 kubernetes_default_network_driver = calico


### PR DESCRIPTION
this allows magnum clusters to be created in testbed "full deploy" after executing:

```
/opt/configuration/scripts/bootstrap/301-openstack-octavia-amhpora-image.sh && \
/opt/configuration/scripts/bootstrap/302-openstack-k8s-clusterapi-images.sh
```

```
openstack --os-cloud admin coe cluster template create \
    --coe kubernetes \
    --image <clusterapi-image-id> \
    --external-network public \
    --dns-nameserver 8.8.8.8 \
    --master-lb-enabled \
    --master-flavor SCS-2V-4-20s \
    --flavor SCS-2V-4-20s \
    --network-driver cilium \
    --docker-storage-driver overlay2 \
    --volume-driver cinder \
    --label kube_tag=v1.30.4 --label keystone_auth_enabled=false \
    k8s-v1.30.4;
```

```
openstack --os-cloud admin coe cluster create --cluster-template k8s-v1.30.4 \
    --master-lb-enabled \
    --master-count 3 \
    --node-count 3 \
    --merge-labels \
    testbedcluster
```