### PR TITLE
Add tech preview of local storage in cinder

### DIFF
--- a/environments/custom/playbook-cinder-driver-dm-clone.yml
+++ b/environments/custom/playbook-cinder-driver-dm-clone.yml
@@ -1,0 +1,36 @@
+---
+- name: Prepare storage nodes for cinder dm-clone driver
+  hosts: storage
+  gather_facts: true
+
+  tasks:
+    - name: Create physical volumes and volume group on empty disks
+      become: True
+      community.general.lvg:
+        vg: local
+        pvresize: True
+        pvs: >-
+          {{
+            ['/dev']
+            | product(
+                ansible_facts['ansible_local']['testbed_ceph_osd_devices_all']
+                | dict2items
+                | map(attribute='key')
+                | list
+                | difference(
+                    ansible_facts['ansible_local']['testbed_ceph_osd_devices']
+                    | dict2items
+                    | map(attribute='key')
+                    | list
+                )
+            )
+            | map('join', '/')
+            | list
+          }}
+    - name: Checkout cinder dm-clone driver
+      become: true
+      ansible.builtin.git:
+        repo: https://github.com/osism/cinder-driver-dm-clone.git
+        dest: "/opt/cinder-driver-dm-clone"
+        update: true
+        version: main

--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -79,6 +79,9 @@ ceilometer_prometheus_pushgateway_host: "testbed-manager"
 ceilometer_metering_pushgateway_host: "testbed-manager"
 ceilometer_metering_pushgateway_port: 8088
 
+# cinder
+enable_cinder_backend_lvm: "yes"
+
 # rgw integration
 
 enable_ceph_rgw: true
@@ -116,3 +119,7 @@ prometheus_external_labels:
 
 om_enable_rabbitmq_high_availability: false
 om_enable_rabbitmq_quorum_queues: false
+
+# cinder dm-clone driver
+cinder_volume_extra_volumes:
+  - "/opt/cinder-driver-dm-clone:/var/lib/kolla/venv/lib/python{{ distro_python_version }}/site-packages/cinder-driver-dm-clone"

--- a/environments/kolla/files/overlays/cinder/cinder-volume.conf
+++ b/environments/kolla/files/overlays/cinder/cinder-volume.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-enabled_backends = rbd-volumes
+enabled_backends = rbd-volumes{{', local-volumes' if inventory_hostname in groups['storage'] else '' }}
 
 [rbd-volumes]
 report_discard_supported = True
@@ -13,3 +13,19 @@ rbd_pool = volumes
 rbd_secret_uuid = {{ cinder_rbd_secret_uuid }}
 
 image_upload_use_cinder_backend = True
+
+{% if inventory_hostname in groups['storage'] -%}
+[local-volumes]
+volume_driver = cinder-driver-dm-clone.cinder.volume.drivers.dmclone.DMCloneVolumeDriver
+volume_group = local
+volume_backend_name = local-volumes
+target_helper = tgtadm
+target_protocol = iscsi
+lvm_type = default
+#metadata_volume_group = LVM.configuration.volume_group
+#metadata_volume_size = 16s
+#clone_region_size = 8
+#clone_no_discard_passdown = False
+#clone_hydration_threshold = None
+#clone_hydration_batch_size = None
+{%- endif %}

--- a/environments/openstack/playbook-bootstrap-basic.yml
+++ b/environments/openstack/playbook-bootstrap-basic.yml
@@ -42,6 +42,17 @@
       when: volume_type_result.rc == 1
       changed_when: true
 
+    - name: Get volume type local
+      ansible.builtin.command: openstack --os-cloud admin volume type show local
+      register: volume_type_local_result
+      changed_when: false
+      failed_when: false
+
+    - name: Create volume type local
+      ansible.builtin.command: openstack --os-cloud admin volume type create --property volume_backend_name=local-volumes local
+      when: volume_type_local_result.rc == 1
+      changed_when: true
+
     - name: Create public network
       openstack.cloud.network:
         cloud: admin

--- a/inventory/99-overwrite
+++ b/inventory/99-overwrite
@@ -16,3 +16,6 @@ testbed-managers
 
 [frr:children]
 testbed-managers
+
+[storage:children]
+compute

--- a/inventory/group_vars/testbed-nodes.yml
+++ b/inventory/group_vars/testbed-nodes.yml
@@ -99,7 +99,8 @@ ceph_osd_devices: "{{ ansible_local.testbed_ceph_osd_devices }}"
 # Old parameter until OSISM 6.0.2
 devices: "{{ ansible_local.testbed_ceph_devices }}"
 
-# NOTE: to use the third block device for Ceph change this parameter as follows
+# NOTE: to use the third block device for Ceph instead of the cinder local
+# volume type change this parameter as follows
 # ceph_osd_devices: "{{ ansible_local.testbed_ceph_osd_devices_all }}"
 # devices: "{{ ansible_local.testbed_ceph_devices }}"
 

--- a/inventory/group_vars/testbed-nodes.yml
+++ b/inventory/group_vars/testbed-nodes.yml
@@ -99,11 +99,6 @@ ceph_osd_devices: "{{ ansible_local.testbed_ceph_osd_devices }}"
 # Old parameter until OSISM 6.0.2
 devices: "{{ ansible_local.testbed_ceph_devices }}"
 
-# NOTE: to use the third block device for Ceph instead of the cinder local
-# volume type change this parameter as follows
-# ceph_osd_devices: "{{ ansible_local.testbed_ceph_osd_devices_all }}"
-# devices: "{{ ansible_local.testbed_ceph_devices }}"
-
 ##########################################################
 # k3s
 

--- a/scripts/deploy/200-infrastructure-services.sh
+++ b/scripts/deploy/200-infrastructure-services.sh
@@ -15,6 +15,7 @@ osism apply mariadb
 osism apply rabbitmq
 osism apply openvswitch
 osism apply ovn
+osism apply iscsi
 
 # In OSISM >= 5.0.0, the switch was made from Elasticsearch / Kibana to Opensearch.
 if [[ ( $(semver $MANAGER_VERSION 5.0.0) -eq -1 && $MANAGER_VERSION != "latest" ) || $OPENSTACK_VERSION == "yoga" ]]; then

--- a/scripts/deploy/300-openstack-services.sh
+++ b/scripts/deploy/300-openstack-services.sh
@@ -4,6 +4,10 @@ set -e
 source /opt/configuration/scripts/include.sh
 source /opt/configuration/scripts/manager-version.sh
 
+# checkout the cinder dm-clone driver and prepare drives
+osism apply -e custom cinder-driver-dm-clone
+
+# apply OpenStack services
 osism apply keystone
 osism apply placement
 osism apply neutron

--- a/scripts/upgrade/200-infrastructure-services.sh
+++ b/scripts/upgrade/200-infrastructure-services.sh
@@ -14,3 +14,4 @@ osism apply -a upgrade mariadb
 osism apply -a upgrade rabbitmq
 osism apply -a upgrade openvswitch
 osism apply -a upgrade ovn
+osism apply -a upgrade iscsi


### PR DESCRIPTION
* Create volume group on third supplied block device
* Checkout cinder dm-clone driver
* Add compute nodes to `storage` group
* Deploy cinder lvm backend and iscsi containers
* Add and enable local backend using dm-clone driver
* Add volume type for local backend