### PR TITLE
manager: do not enable extra netbox plugins

### DIFF
--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -49,9 +49,6 @@ netbox_host: netbox.testbed.osism.xyz
 netbox_traefik: true
 netbox_api_url: "https://{{ netbox_host }}"
 
-netbox_plugins_extra:
-  - netbox_bgp
-
 ##########################
 # opensearch
 


### PR DESCRIPTION
Sometimes they are not yet compatible with latest. In the testbed we should only use plugins that also worked in the CI of the netbox role.

Related to 3acd3ef806aec0f3059f0fad14aa108c8f1c8c7d