### PR TITLE
Do not use testbed-node-[0-2] as k3s nodes in a small testbed

### DIFF
--- a/inventory/20-roles
+++ b/inventory/20-roles
@@ -28,7 +28,7 @@ testbed-resource-nodes
 
 [k3s_node:children]
 testbed-managers
-testbed-resource-nodes
+#testbed-resource-nodes
 
 # NOTE: After the initial import of the inventory in the netbox,
 #       the groups in this file can be emptied. The systems are

--- a/scripts/enable-resource-nodes.sh
+++ b/scripts/enable-resource-nodes.sh
@@ -5,11 +5,12 @@ source /opt/manager-vars.sh
 number_of_resource_nodes=$(expr $NUMBER_OF_NODES - 3)
 
 if [[ $number_of_resource_nodes -gt 0 ]]; then
+    sed -i "/^#testbed-resource-nodes/s/^#//" /opt/configuration/inventory/20-roles
     for node in $(seq 3 $(expr $NUMBER_OF_NODES - 1)); do
-      sed -i "/^#.*testbed-node-$node/s/^#//" /opt/configuration/inventory/10-custom
+      sed -i "/^#testbed-node-$node/s/^#//" /opt/configuration/inventory/10-custom
     done
 else
     for node in $(seq 0 $(expr $NUMBER_OF_NODES - 1)); do
-      sed -i "/^#.*testbed-node-$node/s/^#//" /opt/configuration/inventory/10-custom
+      sed -i "/^#testbed-node-$node/s/^#//" /opt/configuration/inventory/10-custom
     done
 fi


### PR DESCRIPTION
Related to 3a94d651776fb6ba7b85767b489116265101bbd3