### PR TITLE
Increase netbox start period

### DIFF
--- a/environments/infrastructure/configuration.yml
+++ b/environments/infrastructure/configuration.yml
@@ -45,6 +45,9 @@ keycloak_host: keycloak.testbed.osism.xyz
 netbox_traefik: true
 netbox_host: netbox.testbed.osism.xyz
 
+# NOTE: netbox-1 takes some time to start on first run
+netbox_service_netbox_start_period: 300s
+
 ##########################
 # phpmyadmin
 


### PR DESCRIPTION
Fix timeout of manager deployment due to low docker compose healthcheck `start_period`.