### PR TITLE
Apply resolvconf before sshconfig

### DIFF
--- a/scripts/deploy/000-manager-service.sh
+++ b/scripts/deploy/000-manager-service.sh
@@ -77,6 +77,7 @@ if [[ $(semver $MANAGER_VERSION 7.0.0) -ge 0 || $MANAGER_VERSION == "latest" ]];
     sed -i "s/community.general.yaml/osism.commons.still_alive/" /opt/configuration/environments/ansible.cfg
 fi
 
+osism apply resolvconf -l testbed-manager
 osism apply sshconfig
 osism apply known-hosts
 


### PR DESCRIPTION
Required because of e6f916e7aefe2ff2e3a5c3cf8a5670b33cd1f1f0