### PR TITLE
ansible-lint: exclude some more paths

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,6 +4,8 @@ exclude_paths:
   - environments/kolla/files/overlays/ceilometer/event_pipeline.yaml
   - environments/kolla/files/overlays/ceilometer/pipeline.yaml
   - environments/kolla/files/overlays/prometheus/prometheus.yml.d/50-ceph.yml
+  - netbox/playbooks
+  - .zuul.yaml
 mock_modules:
   - netbox.netbox.netbox_device
   - netbox.netbox.netbox_ip_address


### PR DESCRIPTION
The netbox playbooks are failing ansible-lints checks since about a week, the exact cause for that is unclear, let's exclude them for now.

The error for .zuul.yaml seems to only show up for local testing, not in the CI, but keep it excluded, too.