### PR TITLE
ansible-lint: exclude netbox playbooks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,6 +4,7 @@ exclude_paths:
   - environments/kolla/files/overlays/ceilometer/event_pipeline.yaml
   - environments/kolla/files/overlays/ceilometer/pipeline.yaml
   - environments/kolla/files/overlays/prometheus/prometheus.yml.d/50-ceph.yml
+  - netbox/playbooks
 mock_modules:
   - netbox.netbox.netbox_device
   - netbox.netbox.netbox_ip_address


### PR DESCRIPTION
The netbox playbooks are failing ansible-lints checks for some time now, but the exact cause for that is unclear, let's exclude them.