### PR TITLE
Disable ironic_prometheus_exporter

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -72,6 +72,7 @@ ironic_dnsmasq_dhcp_range: "192.168.112.50,192.168.112.60"
 ironic_dnsmasq_dhcp_ranges:
   - range: "192.168.112.50,192.168.112.60"
 ironic_cleaning_network: "public"
+enable_ironic_prometheus_exporter: false
 
 # ceilometer
 enable_ceilometer_prometheus_pushgateway: "yes"


### PR DESCRIPTION
The ironic_prometheus_exporter is broken right now and cannot be scraped. The error is in the ironic-conductor ([1]) while fetching the metrics.

[1]
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager [-] An unknown error occurred while attempting to collect sensor data from within the conductor. Error: Metrics action is not supported. You may need to adjust the [metrics] section in ironic.conf.: ironic_lib.exception.MetricsNotSupported: Metrics action is not supported. You may need to adjust the [metrics] section in iro nic.conf.
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager Traceback (most recent call last):
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager   File "/var/lib/kolla/venv/lib/python3.10/site-packages/ironic/conductor/manager.py", line 2681, in _sensors_conductor
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager     sensors_data = METRICS.get_metrics_data()
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager   File "/var/lib/kolla/venv/lib/python3.10/site-packages/ironic_lib/metrics.py", line 295, in get_metrics_data
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager     raise exception.MetricsNotSupported()
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager ironic_lib.exception.MetricsNotSupported: Metrics action is not supported. You may need to adjust the [metrics] section in ironic.conf.
2024-12-07 10:18:15.321 7 ERROR ironic.conductor.manager
2024-12-07 10:18:45.319 7 DEBUG futurist.periodics [-] Submitting periodic callback 'ironic.conductor.manager.ConductorManager._send_sensor_data' _process_scheduled /var/lib/kolla/venv/lib/python3.10/site-packages/futurist/periodics.py:638
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager [-] An unknown error occurred while attempting to collect sensor data from within the conductor. Error: Metrics action is not supported. You may need to adjust the [metrics] section in ironic.conf.: ironic_lib.exception.MetricsNotSupported: Metrics action is not supported. You may need to adjust the [metrics] section in iro
nic.conf.
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager Traceback (most recent call last):
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager   File "/var/lib/kolla/venv/lib/python3.10/site-packages/ironic/conductor/manager.py", line 2681, in _sensors_conductor
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager     sensors_data = METRICS.get_metrics_data()
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager   File "/var/lib/kolla/venv/lib/python3.10/site-packages/ironic_lib/metrics.py", line 295, in get_metrics_data
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager     raise exception.MetricsNotSupported()
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager ironic_lib.exception.MetricsNotSupported: Metrics action is not supported. You may need to adjust the [metrics] section in ironic.conf.
2024-12-07 10:18:45.321 7 ERROR ironic.conductor.manager