### PR TITLE
Revert "Disable ironic_prometheus_exporter (#2557)"

### DIFF
--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -72,7 +72,6 @@ ironic_dnsmasq_dhcp_range: "192.168.112.50,192.168.112.60"
 ironic_dnsmasq_dhcp_ranges:
   - range: "192.168.112.50,192.168.112.60"
 ironic_cleaning_network: "public"
-enable_ironic_prometheus_exporter: false
 
 # ceilometer
 enable_ceilometer_prometheus_pushgateway: "yes"


### PR DESCRIPTION
Disabling ironic prometheus exporter will happen as a global default in osism. It is not required here.

This reverts commit cd26c5afc35750120ac5177852f881c872322104.