### PR TITLE
Set default neutron availability zone

### DIFF
--- a/environments/kolla/files/overlays/neutron.conf
+++ b/environments/kolla/files/overlays/neutron.conf
@@ -1,2 +1,3 @@
 [DEFAULT]
 global_physnet_mtu = 1400
+default_availability_zones = nova


### PR DESCRIPTION
Set the default availability zone for neutron to the configured `nova` zone. OVN external ports require the availablity zone to be set if zones are configured. Failure to do so will result in an empty `ha_chassis_group`. Setting the zone via `availability-zone-hint` is not supported by ansible module `openstack.cloud.network`.

Part of https://github.com/osism/issues/issues/1196