### PR TITLE
Use network role to create vxlans

### DIFF
--- a/inventory/group_vars/all/vxlan.yml
+++ b/inventory/group_vars/all/vxlan.yml
@@ -1,0 +1,21 @@
+---
+_network_vxlan_interfaces:
+  vxlan0:
+    vni: 42
+    local_ip: "{{ [inventory_hostname] | map('extract', hostvars, 'ansible_facts') | map(attribute=internal_interface) | map(attribute='ipv4') | map(attribute='address') | first }}"
+    dests: "{{ groups['testbed-nodes'] | reject('equalto', inventory_hostname) | map('extract', hostvars, 'ansible_facts') | map(attribute=internal_interface) | map(attribute='ipv4') | map(attribute='address') | list }}"
+    addresses: >-
+      {{
+        [
+          '192.168.112.0/20' | ansible.utils.ipaddr('net')
+                             | ansible.utils.ipaddr(node_id)
+                             | ansible.utils.ipaddr('address')
+          + '/20'
+        ] if inventory_hostname in groups['testbed-managers'] else []
+      }}
+  vxlan1:
+    vni: 23
+    local_ip: "{{ [inventory_hostname] | map('extract', hostvars, 'ansible_facts') | map(attribute=internal_interface) | map(attribute='ipv4') | map(attribute='address') | first }}"
+    dests: "{{ groups['testbed-nodes'] | reject('equalto', inventory_hostname) | map('extract', hostvars, 'ansible_facts') | map(attribute=internal_interface) | map(attribute='ipv4') | map(attribute='address') | list }}"
+    addresses:
+      - "{{ '192.168.128.0/20' | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(node_id) | ansible.utils.ipaddr('address') }}/20"

--- a/inventory/group_vars/testbed-control-nodes.yml
+++ b/inventory/group_vars/testbed-control-nodes.yml
@@ -1,0 +1,2 @@
+---
+network_vxlan_interfaces: "{{ _network_vxlan_interfaces }}"

--- a/inventory/group_vars/testbed-managers.yml
+++ b/inventory/group_vars/testbed-managers.yml
@@ -37,11 +37,15 @@ network_ethernets:
   "{{ internal_interface }}":
     dhcp4: true
     mtu: "{{ testbed_mtu_manager }}"
+
+# NOTE: Only add vxlan.sh for osism < 9.0.0 or latest
 network_dispatcher_scripts:
-  - src: /opt/configuration/network/vxlan.sh
-    dest: routable.d/vxlan.sh
+#   - src: /opt/configuration/network/vxlan.sh
+#     dest: routable.d/vxlan.sh
   - src: /opt/configuration/network/iptables.sh
     dest: routable.d/iptables.sh
+
+network_vxlan_interfaces: "{{ _network_vxlan_interfaces }}"
 
 ##########################################################
 # kolla

--- a/inventory/group_vars/testbed-nodes.yml
+++ b/inventory/group_vars/testbed-nodes.yml
@@ -74,9 +74,10 @@ network_ethernets:
     dhcp4: true
     mtu: "{{ testbed_mtu_node }}"
 
-network_dispatcher_scripts:
-  - src: /opt/configuration/network/vxlan.sh
-    dest: routable.d/vxlan.sh
+# NOTE: Only add vxlan.sh for osism < 9.0.0 or latest
+# network_dispatcher_scripts:
+#   - src: /opt/configuration/network/vxlan.sh
+#     dest: routable.d/vxlan.sh
 
 ##########################################################
 # kolla

--- a/scripts/deploy/000-manager.sh
+++ b/scripts/deploy/000-manager.sh
@@ -97,3 +97,15 @@ if [[ $(semver $MANAGER_VERSION 7.0.0) -ge 0 || $MANAGER_VERSION == "latest" ]];
 fi
 
 osism apply squid
+
+# Enable vxlan.sh networkd-dispatcher script for OSISM <= 9.0.0
+if [[ $MANAGER_VERSION != "latest" && $(semver $MANAGER_VERSION 9.0.0) -lt 0 ]]; then
+	sed -i 's|^# \(network_dispatcher_scripts:\)$|\1|g' \
+		inventory/group_vars/testbed-nodes.yml
+	sed -i 's|^# \(  - src: /opt/configuration/network/vxlan.sh\)$|\1|g' \
+		inventory/group_vars/testbed-nodes.yml \
+		inventory/group_vars/testbed-managers.yml
+	sed -i 's|^# \(    dest: routable.d/vxlan.sh\)$|\1|g' \
+		inventory/group_vars/testbed-nodes.yml \
+		inventory/group_vars/testbed-managers.yml
+fi


### PR DESCRIPTION
Use the network role to create vxlans. This is mostly a drop-in
replacement with the exception that it does not add IP addresses to the
`vxlan0` interface except for the manager node. Since the vxlan is used
as a neutron external network attached to an openvswitch bridge on all
nodes except for the manager, the address is unusable there anyway

Part of https://github.com/osism/issues/issues/1196
Depends on https://github.com/osism/ansible-collection-commons/pull/749
Depends on https://github.com/osism/ansible-collection-commons/pull/754