### PR TITLE
Add baremetal deployment

### DIFF
--- a/environments/custom/files/baremetal-tenks-override.yml
+++ b/environments/custom/files/baremetal-tenks-override.yml
@@ -1,0 +1,63 @@
+---
+# node_types is a dict that defines different sets of node specifications,
+# keyed by a 'node type name' to associate with each set of specifications.
+node_types:
+  # The type name.
+  type0:
+    # The amount of RAM, in mebibytes.
+    memory_mb: 4096
+    # The number of virtual CPUs.
+    vcpus: 2
+    # A list of volumes, each with a capacity.
+    volumes:
+      - capacity: 5GB
+    # A list of physical network names to connect to. These physical network
+    # names should be keyed in `physnet_mappings` in each hypervisor's host
+    # vars.
+    physical_networks:
+      - physnet0
+
+# specs is a list of configurations of nodes to be created. Each configuration
+# can specify the number of nodes to be created, the type (from `node_types`)
+# of these nodes, and optionally configuration for the Ironic nodes to be
+# enroled from these nodes. If `ironic_config` is not set, Ironic enrolment
+# will be skipped for that spec.
+specs:
+    # The type in `node_types` that this spec refers to. Required.
+  - type: type0
+    # The number of nodes to create of this spec. Required.
+    count: 6
+    # The Ironic configuration for nodes of this spec. Optional.
+    # ironic_config:
+    #   # The resource class that nodes of this spec should use in Ironic.
+    #   # Required if `ironic_config` has been specified.
+    #   resource_class: my_rc
+
+# Map physical network names to their source device. This can be either an
+# existing interface or an existing bridge.
+# Remember that if the mappings are specified in this file, they will apply to
+# all hosts unless specific mappings are specified in individual host_vars
+# files.
+physnet_mappings:
+  physnet0: vxlan0
+
+# Maps Ironic drivers to the BMC emulation tool they support.
+bmc_emulators:
+  agent_ipmitool: virtualbmc
+  agent_ipmitool_socat: virtualbmc
+  ipmi: virtualbmc
+  pxe_ipmitool: virtualbmc
+  pxe_ipmitool_socat: virtualbmc
+  pxe_snmp: virtualpdu
+  redfish: sushy-tools
+  snmp: virtualpdu
+
+# The address on which VBMC will listen for node IPMI communication.
+ipmi_address: "{{ hostvars[inventory_hostname].ansible_facts['vxlan_oob']['ipv4']['address'] }}"
+# The range of ports available for use for node IPMI communication.
+ipmi_port_range_start: 6230
+ipmi_port_range_end: 6240
+# The username to use for node IPMI communication.
+ipmi_username: admin
+# The password to use for node IPMI communication.
+ipmi_password: password

--- a/environments/custom/playbook-baremetal-bootstrap.yml
+++ b/environments/custom/playbook-baremetal-bootstrap.yml
@@ -1,0 +1,157 @@
+---
+- name: Bootstrap baremetal resources
+  hosts: testbed-control-nodes
+  vars:
+    ironic_network_interface: ironic-boot
+  tasks:
+    - name: Create public network
+      delegate_to: localhost
+      run_once: true
+      openstack.cloud.network:
+        cloud: admin
+        state: present
+        name: public
+        external: false
+        provider_network_type: flat
+        provider_physical_network: physnet1
+        mtu: 1342  # NOTE: necessary because VxLAN in Geneve/VxLAN
+      register: public_network
+
+    - name: Create public subnet
+      delegate_to: localhost
+      run_once: true
+      openstack.cloud.subnet:
+        cloud: admin
+        state: present
+        name: public
+        network_name: public
+        cidr: 192.168.112.0/20
+        enable_dhcp: true
+        allocation_pool_start: 192.168.112.100
+        allocation_pool_end: 192.168.112.200
+        gateway_ip: 192.168.112.5
+      register: public_subnet
+
+    - name: Create Ironic boot port security group
+      delegate_to: localhost
+      run_once: true
+      openstack.cloud.security_group:
+        cloud: admin
+        state: present
+        name: ironic-boot-port
+      register: ironic_sec_grp
+
+    - name: Add rules for security groups
+      delegate_to: localhost
+      run_once: true
+      openstack.cloud.security_group_rule:
+        cloud: admin
+        security_group: "{{ ironic_sec_grp.security_group.id }}"
+        protocol: "{{ item.protocol }}"
+        port_range_min: "{{ item.min_port | default(omit) }}"
+        port_range_max: "{{ item.max_port | default(omit) }}"
+        ethertype: "IPv{{ public_subnet.subnet.ip_version }}"
+      loop:
+        - protocol: icmp
+        - protocol: udp
+          min_port: 69
+          max_port: 69
+        - protocol: tcp
+          min_port: 8089
+          max_port: 8089
+
+    - name: Create ports for Ironic tftpd/httpd nodes
+      delegate_to: localhost
+      openstack.cloud.port:
+        cloud: admin
+        state: present
+        network: "{{ public_network.network.id }}"
+        security_groups: "{{ ironic_sec_grp.security_group.id }}"
+        device_owner: 'ironic:boot'
+        name: "ironic-listen-port-{{ inventory_hostname }}"
+      register: ironic_port
+
+    # ansible os_port module does not support 'host' parameter, but we need set the port's host
+    # value to loop_var, once os_port support this parameter, remove the task below
+    # https://docs.ansible.com/ansible/latest/modules/os_port_module.html#parameters
+    - name: Update Ironic tftpd/httpd port host_id
+      delegate_to: localhost
+      ansible.builtin.command: >
+        openstack
+        --os-cloud admin
+        port set --host {{ inventory_hostname }} {{ ironic_port.port.id }}
+      changed_when: true
+      when:
+        - ironic_port.port.binding_host_id != inventory_hostname
+
+    - name: Check OVS ironic port
+      ansible.builtin.command: >-
+        docker exec openvswitch_vswitchd ovs-vsctl --columns external_ids --data json --format json list Interface {{ ironic_network_interface }}
+      changed_when: false
+      failed_when: false
+      register: check_ovs_ironic_port
+
+    - name: Add Ironic port to openvswitch br-int
+      vars:
+        ovs_interface_data: "{{ dict((check_ovs_ironic_port.stdout | from_json)['data'] | flatten(levels=2) | last) if check_ovs_ironic_port.rc == 0 else None }}"
+      ansible.builtin.command: >
+        docker exec openvswitch_vswitchd ovs-vsctl --may-exist \
+        add-port br-int {{ ironic_network_interface }} \
+        -- set Interface {{ ironic_network_interface }} type=internal \
+        -- set Interface {{ ironic_network_interface }} external-ids:iface-status=active \
+        -- set Interface {{ ironic_network_interface }} external-ids:attached-mac={{ ironic_port.port.mac_address }} \
+        -- set Interface {{ ironic_network_interface }} external-ids:iface-id={{ ironic_port.port.id }} \
+        -- set Interface {{ ironic_network_interface }} external-ids:skip_cleanup=true
+      register: ovs_ironic_port
+      changed_when: true
+      failed_when: ovs_ironic_port.rc != 0
+      when: >
+        not ovs_interface_data
+        or
+        ovs_interface_data['iface-status'] != 'active'
+        or
+        ovs_interface_data['attached-mac'] != ironic_port.port.mac_address
+        or
+        ovs_interface_data['iface-id'] != ironic_port.port.id
+        or
+        ovs_interface_data['skip_cleanup'] != 'true'
+
+    - name: Create ironic dhclient conf
+      become: true
+      ansible.builtin.copy:
+        content: |
+          request subnet-mask,broadcast-address,interface-mtu;
+          do-forward-updates false;
+        dest: /etc/dhcp/ironic-dhclient.conf
+        mode: 0664
+      notify: Restart ironic-interface.service
+
+    - name: Create ironic-interface service
+      become: True
+      ansible.builtin.template:
+        src: ironic-interface.service.j2
+        dest: /etc/systemd/system/ironic-interface.service
+        mode: 0644
+      notify: Restart ironic-interface.service
+
+    - name: Flush handlers
+      ansible.builtin.meta: flush_handlers
+
+    - name: Wait for ip to appear on interface {{ ironic_network_interface }}
+      ansible.builtin.setup:
+        gather_subset:
+          - '!all'
+          - '!min'
+          - network
+      until: ironic_port.port.fixed_ips[0].ip_address == ansible_facts[ironic_network_interface | replace('-', '_')]['ipv' + public_subnet.subnet.ip_version | string]['address']
+      retries: 5
+      delay: 2
+
+  handlers:
+    - name: Restart ironic-interface.service
+      become: True
+      ansible.builtin.systemd_service:
+        name: ironic-interface.service
+        daemon_reload: yes
+        state: restarted
+        enabled: yes

--- a/environments/custom/playbook-baremetal-prepare.yml
+++ b/environments/custom/playbook-baremetal-prepare.yml
@@ -1,0 +1,34 @@
+---
+- name: Prepare baremetal deployment
+  hosts: testbed-managers
+  tasks:
+    - name: Add resource nodes to tenks hypervisors
+      ansible.builtin.copy:
+        content: |
+          [libvirt:children]
+          testbed-resource-nodes
+        dest: /opt/configuration/inventory/50-tenks.yml
+        mode: '0644'
+        owner: dragon
+        group: dragon
+    - name: Add networks to testbed-node group_vars
+      ansible.builtin.copy:
+        content: |
+          {% raw -%}
+          ---
+          _network_vxlan_interface_vxlan_oob:
+            vxlan-oob:
+              vni: 65
+              local_ip: "{{ [inventory_hostname] | map('extract', hostvars, 'ansible_facts') | map(attribute=internal_interface) | map(attribute='ipv4') | map(attribute='address') | first }}"
+              dests: "{{ groups['testbed-nodes'] | reject('equalto', inventory_hostname) | map('extract', hostvars, 'ansible_facts') | map(attribute=internal_interface) | map(attribute='ipv4') | map(attribute='address') | list }}"
+              addresses:
+                - "{{ '172.16.0.0/20' | ansible.utils.ipaddr('net') | ansible.utils.ipaddr(node_id) | ansible.utils.ipaddr('address') }}/20"
+          network_vxlan_interfaces: "{{ _network_vxlan_interfaces | combine(_network_vxlan_interface_vxlan_oob) }}"
+          {% endraw -%}
+        dest: "{{ item }}"
+        mode: '0644'
+        owner: dragon
+        group: dragon
+      loop:
+        - /opt/configuration/inventory/group_vars/testbed-control-nodes.yml
+        - /opt/configuration/inventory/group_vars/testbed-resource-nodes.yml

--- a/environments/custom/templates/ironic-interface.service.j2
+++ b/environments/custom/templates/ironic-interface.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=Ironic Interface Creator
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+Restart=on-failure
+{% if ironic_interface_wait_timeout is defined %}
+TimeoutStartSec={{ ironic_interface_wait_timeout }}
+{% endif %}
+RemainAfterExit=true
+ExecStartPre=/sbin/ip link set dev {{ ironic_network_interface }} address {{ ironic_port.port.mac_address }}
+ExecStart=/sbin/dhclient -v {{ ironic_network_interface }} -cf /etc/dhcp/ironic-dhclient.conf
+ExecStop=/sbin/dhclient -r {{ ironic_network_interface }}
+
+[Install]
+WantedBy=multi-user.target

--- a/environments/kolla/configuration.yml
+++ b/environments/kolla/configuration.yml
@@ -68,6 +68,8 @@ ironic_dnsmasq_dhcp_range: "192.168.112.50,192.168.112.60"
 ironic_dnsmasq_dhcp_ranges:
   - range: "192.168.112.50,192.168.112.60"
 ironic_cleaning_network: "public"
+ironic_tftp_interface: ironic-boot
+ironic_http_interface: ironic-boot
 
 # ceilometer
 enable_ceilometer_prometheus_pushgateway: "yes"

--- a/environments/kolla/files/overlays/ironic/ironic-conductor.conf
+++ b/environments/kolla/files/overlays/ironic/ironic-conductor.conf
@@ -1,0 +1,10 @@
+[pxe]
+tftp_server = {{ ironic_tftp_listen_address }}
+# NOTE: set kernel cmdline for IPA image
+# - nofb:
+# - vga=normal:
+# - console=tty0:
+# - console=ttyS0,115200n8:
+# - ipa-insecure=1: Instruct ironic python agent to not verify certificates (testbed internal API uses self-signed certs)
+# - sshkey="{{ lookup('file', '/ansible/secrets/id_rsa.operator.pub') }}": Inject operator ssh pub key using the dynamic-login DIB element (Use path from inside the kolla-ansible container)
+kernel_append_params = nofb vga=normal console=tty0 console=ttyS0,115200n8 ipa-insecure=1 sshkey="{{ lookup('file', '/ansible/secrets/id_rsa.operator.pub') }}"

--- a/scripts/deploy-baremetal.sh
+++ b/scripts/deploy-baremetal.sh
@@ -9,14 +9,51 @@ echo
 source /opt/configuration/scripts/include.sh
 source /opt/manager-vars.sh
 
-osism apply openstackclient
+osism apply -e custom baremetal-prepare
+osism sync inventory
+osism apply network -e network_allow_service_restart=true
+
+# pull images
+sh -c '/opt/configuration/scripts/pull-images.sh'
 
 osism apply common
 osism apply loadbalancer
+osism apply openstackclient
 osism apply memcached
+osism apply redis
 osism apply mariadb
 osism apply rabbitmq
+osism apply openvswitch --limit testbed-control-nodes
+osism apply ovn --limit testbed-control-nodes
+
+# deploy ceph services
+if [[ $CEPH_STACK == "ceph-ansible" ]]; then
+    sh -c '/opt/configuration/scripts/deploy/100-ceph-with-ansible.sh'
+elif [[ $CEPH_STACK == "rook" ]]; then
+    sh -c '/opt/configuration/scripts/deploy/100-ceph-with-rook.sh'
+fi
+
 osism apply keystone
+osism apply placement
+osism apply neutron
+
+osism apply -e custom baremetal-bootstrap
+osism sync facts
+osism apply ironic
+
+osism apply glance
+osism apply nova --limit testbed-control-nodes
+
+osism apply tenks -e ireallymeanit=yes -e tenks_override_file=/opt/configuration/environments/custom/files/baremetal-tenks-override.yml
+
+osism apply designate
+osism apply kolla-ceph-rgw
 osism apply horizon
+osism apply skyline
+osism apply cinder
+osism apply barbican
+osism apply octavia
+osism apply ceilometer
+osism apply aodh
 
 osism apply homer


### PR DESCRIPTION
Add a deployment scenario, where `testbed-resource-nodes` are used to
provide virtual machines for baremetal deployment.
Virtual baremetal machines are created using `tenks` ([1]), which may
later also be used to register baremetal nodes and create matching
flavors.
The network `vxlan0`, which serves as an external network in ordinary
deployments is used as a provider network conected to the virtual
baremetal. Additionally an out-of-band network is created to manage the
machines via virtual BMC.
Since routing to the API network did not seem to work during PXE
booting, ports are created for the ironic tftp and httpd services and
connected to the control plane in a similar way to what is done in kolla
for octavia amphora management networks ([2]). Routing to the ironic API
during callback of the ironic python agent image works fine and is done
via the manager node.

[1]
https://docs.openstack.org/tenks

[2]
https://opendev.org/openstack/kolla-ansible/src/branch/master/ansible/roles/octavia/tasks/hm-interface.yml

Part of https://github.com/osism/issues/issues/1196
Depends on https://github.com/osism/testbed/pull/2606
Depends on https://github.com/osism/ansible-playbooks/pull/527