### PR TITLE
Use vxlan networkd dispatcher script for the moment

### DIFF
--- a/inventory/group_vars/testbed-managers.yml
+++ b/inventory/group_vars/testbed-managers.yml
@@ -41,11 +41,8 @@ network_ethernets:
 network_dispatcher_scripts:
   - src: /opt/configuration/network/iptables.sh
     dest: routable.d/iptables.sh
-# Only use vxlan.sh networkd-dispatcher script for OSISM < 9.0.0
-#   - src: /opt/configuration/network/vxlan.sh
-#     dest: routable.d/vxlan.sh
-
-network_vxlan_interfaces: "{{ _network_vxlan_interfaces }}"
+  - src: /opt/configuration/network/vxlan.sh
+    dest: routable.d/vxlan.sh
 
 ##########################################################
 # kolla

--- a/inventory/group_vars/testbed-nodes.yml
+++ b/inventory/group_vars/testbed-nodes.yml
@@ -72,12 +72,9 @@ network_ethernets:
     dhcp4: true
     mtu: "{{ testbed_mtu_node }}"
 
-network_vxlan_interfaces: "{{ _network_vxlan_interfaces }}"
-
-# Only use vxlan.sh networkd-dispatcher script for OSISM < 9.0.0
-# network_dispatcher_scripts:
-#   - src: /opt/configuration/network/vxlan.sh
-#     dest: routable.d/vxlan.sh
+network_dispatcher_scripts:
+  - src: /opt/configuration/network/vxlan.sh
+    dest: routable.d/vxlan.sh
 
 ##########################################################
 # kolla

--- a/scripts/deploy/000-manager.sh
+++ b/scripts/deploy/000-manager.sh
@@ -85,15 +85,3 @@ osism apply squid
 if [[ $MANAGER_VERSION != "latest" ]]; then
   sed -i "s#docker_namespace: kolla#docker_namespace: kolla/release#" /opt/configuration/inventory/group_vars/all/kolla.yml
 fi
-
-# use vxlan.sh networkd-dispatcher script for OSISM <= 9.0.0
-if [[ $(semver $MANAGER_VERSION 9.0.0) -lt 0 && $MANAGER_VERSION != "latest" ]]; then
-    sed -i 's|^# \(network_dispatcher_scripts:\)$|\1|g' \
-      /opt/configuration/inventory/group_vars/testbed-nodes.yml
-    sed -i 's|^# \(  - src: /opt/configuration/network/vxlan.sh\)$|\1|g' \
-      /opt/configuration/inventory/group_vars/testbed-nodes.yml \
-      /opt/configuration/inventory/group_vars/testbed-managers.yml
-    sed -i 's|^# \(    dest: routable.d/vxlan.sh\)$|\1|g' \
-      /opt/configuration/inventory/group_vars/testbed-nodes.yml \
-      /opt/configuration/inventory/group_vars/testbed-managers.yml
-fi


### PR DESCRIPTION
Something is broken with the vxlan netdev approach. The created vxlan is not usable for the simulation of the public network.