### PR TITLE
Revert "Use vxlan networkd dispatcher script for the moment"

### DIFF
--- a/inventory/group_vars/testbed-managers.yml
+++ b/inventory/group_vars/testbed-managers.yml
@@ -41,8 +41,11 @@ network_ethernets:
 network_dispatcher_scripts:
   - src: /opt/configuration/network/iptables.sh
     dest: routable.d/iptables.sh
-  - src: /opt/configuration/network/vxlan.sh
-    dest: routable.d/vxlan.sh
+# Only use vxlan.sh networkd-dispatcher script for OSISM < 9.0.0
+#   - src: /opt/configuration/network/vxlan.sh
+#     dest: routable.d/vxlan.sh
+
+network_vxlan_interfaces: "{{ _network_vxlan_interfaces }}"
 
 ##########################################################
 # kolla

--- a/inventory/group_vars/testbed-nodes.yml
+++ b/inventory/group_vars/testbed-nodes.yml
@@ -72,9 +72,12 @@ network_ethernets:
     dhcp4: true
     mtu: "{{ testbed_mtu_node }}"
 
-network_dispatcher_scripts:
-  - src: /opt/configuration/network/vxlan.sh
-    dest: routable.d/vxlan.sh
+network_vxlan_interfaces: "{{ _network_vxlan_interfaces }}"
+
+# Only use vxlan.sh networkd-dispatcher script for OSISM < 9.0.0
+# network_dispatcher_scripts:
+#   - src: /opt/configuration/network/vxlan.sh
+#     dest: routable.d/vxlan.sh
 
 ##########################################################
 # kolla

--- a/scripts/deploy/000-manager.sh
+++ b/scripts/deploy/000-manager.sh
@@ -85,3 +85,15 @@ osism apply squid
 if [[ $MANAGER_VERSION != "latest" ]]; then
   sed -i "s#docker_namespace: kolla#docker_namespace: kolla/release#" /opt/configuration/inventory/group_vars/all/kolla.yml
 fi
+
+# use vxlan.sh networkd-dispatcher script for OSISM <= 9.0.0
+if [[ $(semver $MANAGER_VERSION 9.0.0) -lt 0 && $MANAGER_VERSION != "latest" ]]; then
+    sed -i 's|^# \(network_dispatcher_scripts:\)$|\1|g' \
+      /opt/configuration/inventory/group_vars/testbed-nodes.yml
+    sed -i 's|^# \(  - src: /opt/configuration/network/vxlan.sh\)$|\1|g' \
+      /opt/configuration/inventory/group_vars/testbed-nodes.yml \
+      /opt/configuration/inventory/group_vars/testbed-managers.yml
+    sed -i 's|^# \(    dest: routable.d/vxlan.sh\)$|\1|g' \
+      /opt/configuration/inventory/group_vars/testbed-nodes.yml \
+      /opt/configuration/inventory/group_vars/testbed-managers.yml
+fi


### PR DESCRIPTION
This reverts commit d013f0cbb53653e5b9aead5bcd4518a8960aa53e.

Fixed by osism/ansible-collection-commons#765