### PR TITLE
Do not longer pull osism-netbox and heat images

### DIFF
--- a/ansible/manager-part-3.yml
+++ b/ansible/manager-part-3.yml
@@ -48,7 +48,6 @@
       - "{{ netbox_image }}"
       - "{{ osism_ansible_image }}"
       - "{{ osism_image }}"
-      - "{{ osism_netbox_image }}"
       - "{{ postgres_image }}"
       - "{{ traefik_image }}"
       - "{{ vault_image }}"

--- a/environments/custom/playbook-pull-images.yml
+++ b/environments/custom/playbook-pull-images.yml
@@ -12,7 +12,6 @@
       - designate
       - glance
       - grafana
-      - heat
       - horizon
       - ironic
       - loadbalancer


### PR DESCRIPTION
The images are not always required and therefore no longer need to be pulled in advance.