### PR TITLE
Disable containerd image store on Docker Engine

### DIFF
--- a/ansible/manager-part-2.yml
+++ b/ansible/manager-part-2.yml
@@ -54,8 +54,6 @@
   vars:
     manager_version: latest
 
-    docker_configure_repository: true
-    docker_storage_containerd_snapshotter: true
     docker_user: dragon
     docker_opts:
       max-concurrent-downloads: 20

--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -12,7 +12,6 @@ testbed_mtu_node: "{{ testbed_mtu }}"
 docker_user: "{{ operator_user }}"
 docker_opts:
   max-concurrent-downloads: 20
-docker_storage_containerd_snapshotter: true
 
 ##########################
 # operator


### PR DESCRIPTION
It actually leads to pretty large images without any benefit for us.

Related to a1ea9dbd63b28e627490bbe1f7035647bd0f8071 Related to aa744612f65f430bf2d9a00552fd733d105b2475