### PR TITLE
manager: cleanup parameters of osism.commons.configuration

### DIFF
--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -62,11 +62,6 @@ manager_opensearch_address: api-int.testbed.osism.xyz
 ##########################
 # configuration
 
-configuration_directory: /opt/configuration
-
-configuration_type: git
-configuration_git_version: main
-configuration_git_host: github.com
 configuration_git_port: 443
-configuration_git_repository: osism/testbed.git
 configuration_git_protocol: https
+configuration_git_repository: osism/testbed.git


### PR DESCRIPTION
Remove parameters that are set by default.