### PR TITLE
Disable ceph during baremetal scenario

### DIFF
--- a/scripts/deploy-baremetal.sh
+++ b/scripts/deploy-baremetal.sh
@@ -10,6 +10,8 @@ source /opt/configuration/scripts/include.sh
 source /opt/manager-vars.sh
 
 sed -i 's/enable_ironic: "no"/enable_ironic: "yes"/' /opt/configuration/environments/kolla/configuration.yml
+sed -i 's/glance_backend_ceph: "yes"/glance_backend_ceph: "no"/' /opt/configuration/environments/kolla/configuration.yml
+sed -i 's/glance_backend_file: "no"/glance_backend_file: "yes"/' /opt/configuration/environments/kolla/configuration.yml
 
 osism apply -e custom baremetal-prepare
 osism sync inventory
@@ -28,13 +30,6 @@ osism apply rabbitmq
 osism apply openvswitch --limit testbed-control-nodes
 osism apply ovn --limit testbed-control-nodes
 
-# deploy ceph services
-if [[ $CEPH_STACK == "ceph-ansible" ]]; then
-    sh -c '/opt/configuration/scripts/deploy/100-ceph-with-ansible.sh'
-elif [[ $CEPH_STACK == "rook" ]]; then
-    sh -c '/opt/configuration/scripts/deploy/100-ceph-with-rook.sh'
-fi
-
 osism apply keystone
 osism apply placement
 osism apply neutron
@@ -51,9 +46,7 @@ osism apply -e custom baremetal-netbox
 sh -c '/opt/configuration/scripts/bootstrap/000-netbox.sh'
 
 osism apply designate
-osism apply kolla-ceph-rgw
 osism apply horizon
-osism apply cinder
 osism apply barbican
 osism apply octavia
 


### PR DESCRIPTION
Ceph takes a long time to deploy and using it is not central to the baremetal scenario.
Use the file backend for glance and do not deploy cinder and kolla-ceph-rgw.