### PR TITLE
Use awk instead of yq in scripts/manager-versions.h

### DIFF
--- a/ansible/manager-part-0.yml
+++ b/ansible/manager-part-0.yml
@@ -60,7 +60,6 @@
               - python3.11
               - python3.11-devel
               - python3.11-pip
-              - yq
             state: present
             lock_timeout: "{{ dnf_lock_timeout }}"
 
@@ -124,7 +123,6 @@
               - python3-netaddr
               - python3-venv
               - rsync
-              - yq
 
         - name: Remove some python packages
           become: true

--- a/scripts/manager-version.sh
+++ b/scripts/manager-version.sh
@@ -1,1 +1,1 @@
-export MANAGER_VERSION=$(yq -M -r .manager_version "/opt/configuration/environments/manager/configuration.yml")
+export MANAGER_VERSION=$(awk -F': ' '/^manager_version:/ { print $2 }' /opt/configuration/environments/manager/configuration.yml)


### PR DESCRIPTION
This ways it's not necessary to install yq. yq is only required to extract the version of the manager.

Part of osism/testbed#2664