### PR TITLE
Use netbox custom field ironic_parameters

### DIFF
--- a/environments/custom/templates/baremetal-netbox-device.yml.j2
+++ b/environments/custom/templates/baremetal-netbox-device.yml.j2
@@ -12,8 +12,9 @@
     device_type: Baremetal-Device
     device_role: Generic
     custom_fields:
-      oob_address: {{ oob_address }}
-      oob_port: {{ oob_port }}
+      ironic_parameters:
+        ipmi_address: {{ oob_address }}
+        ipmi_port: {{ oob_port }}
     tags:
       - managed-by-osism
       - managed-by-ironic


### PR DESCRIPTION
Netbox custom fields

* oob_address
* oob_port

were removed in [1].
Usage of these fields is thus removed here as well. Instead parameters will be overridden using the `ironic_parameters` custom field introduced in [2].

[1]
osism/ansible-collection-services#1821

[2]
https://github.com/osism/ansible-collection-services/pull/1824 https://github.com/osism/python-osism/pull/1326