### PR TITLE
Fix deprecated zuul syntax

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -19,8 +19,10 @@
     pre-run: playbooks/pre.yml
     nodeset: testbed-orchestrator
     run: playbooks/deploy.yml
-    post-run: playbooks/post.yml
-    cleanup-run: playbooks/cleanup.yml
+    post-run:
+      - playbooks/post.yml
+      - name: playbooks/cleanup.yml
+        cleanup: true
     required-projects:
       - osism/ansible-collection-commons
       - osism/ansible-collection-services


### PR DESCRIPTION
Zuul has deprecated the "cleanup-run" parameter, this is to be replaced by "post-run" with the cleanup attribute set to true.