### PR TITLE
Fix MAC addresses in baremetal scenario

### DIFF
--- a/environments/custom/playbook-baremetal-netbox.yml
+++ b/environments/custom/playbook-baremetal-netbox.yml
@@ -43,14 +43,22 @@
       ansible.builtin.command:
         argv:
           - /usr/bin/virsh
+          - --quiet
           - domiflist
           - "{{ item.1['Domain name'] }}"
       loop: "{{ dict(nodes | zip(vms)) | dict2items | subelements('value') }}"
 
     - name: Add netbox resources for virtualized baremetal nodes
+      vars:
+        node: "{{ item.item.0.key }}"
+        bay: "{{ item.item.1['Domain name'] }}"
+        device_name: "housing-{{ node | split('-') | last }}-{{ bay }}"
+        oob_address: "{{ item.item.1['Address'] }}"
+        oob_port: "{{ item.item.1['Port'] }}"
+        macs: "{{ item.stdout_lines | map('split', ' ') | map('last') | list }}"
       ansible.builtin.template:
         src: templates/baremetal-netbox-device.yml.j2
-        dest: "/opt/configuration/netbox/resources/400-rack-1000-{{ item.item.0.key }}-{{ item.item.1['Domain name']}}.yml"
+        dest: "/opt/configuration/netbox/resources/400-rack-1000-{{ device_name }}.yml"
         mode: 0644
         owner: dragon
         group: dragon

--- a/environments/custom/templates/baremetal-netbox-device.yml.j2
+++ b/environments/custom/templates/baremetal-netbox-device.yml.j2
@@ -1,11 +1,6 @@
 ---
-{% set node = item.item.0.key -%}
-{% set name = item.item.1['Domain name'] -%}
-{% set oob_address = item.item.1['Address'] -%}
-{% set oob_port = item.item.1['Port'] -%}
-{% set macs = item.stdout_lines[2:] | map('split', ' ') | map('last') | list -%}
 - device:
-    name: {{ node }}-{{ name }}
+    name: {{ device_name }}
     site: Discworld
     location: Ankh-Morpork
     rack: "1000"
@@ -23,12 +18,18 @@
 
 - device_bay:
     device: {{ node }}
-    name: {{ name }}
-    installed_device: {{ node }}-{{ name }}
+    name: {{ bay }}
+    installed_device: {{ device_name }}
 
 {% for mac in macs -%}
+- mac_address:
+    mac_address: {{ mac }}
+    assigned_object:
+      name: Ethernet{{ loop.index }}
+      device: {{ device_name }}
+
 - device_interface:
     name: Ethernet{{ loop.index }}
-    device: {{ node }}-{{ name }}
-    mac_address: {{ mac }}
+    device: {{ device_name }}
+    primary_mac_address: {{ mac }}
 {% endfor %}


### PR DESCRIPTION
Netbox 4.2 requires the mac addresses to be explicitly created and assigned to the device as primary address.

Additionally the naming of virtual baremetal devices in the netbox is changed and `--quiet` flag is used to find libvirt mac addresses.