### PR TITLE
Remove netbox initialization from manager deployment script

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -32,6 +32,7 @@
       - ^LICENSE$
       - ^README.md$
       - ^\.github/.*$
+      - ^netbox/.*$
     # NOTE(frickler): Default zuul maximum timeout is 3h, this needs to
     # be explicitly bumped in the tenant configuration
     timeout: 16200

--- a/scripts/deploy/000-manager.sh
+++ b/scripts/deploy/000-manager.sh
@@ -61,12 +61,6 @@ if [[ "$IS_ZUUL" == "true" || "$ARA" == "false" ]]; then
     sh -c '/opt/configuration/scripts/disable-ara.sh'
 fi
 
-# initialize netbox
-if [[ $(semver $MANAGER_VERSION 9.0.0) -ge 0 || $MANAGER_VERSION == "latest" ]]; then
-    wait_for_container_healthy 60 netbox-netbox-1
-    /opt/configuration/scripts/bootstrap/000-netbox.sh
-fi
-
 docker compose --project-directory /opt/manager ps
 docker compose --project-directory /opt/netbox ps
 


### PR DESCRIPTION
We only use the Netbox in the bare metal testbed. To save time, we skip the initialisation in the normal testbed. For demos, initialisation can be done later with osism manage netbox.