### PR TITLE
Add deploy mode support for conditional netbox deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@ CLOUD ?= $(ENVIRONMENT)
 
 IMAGE_USERNAME ?= ubuntu
 
+CEPH_STACK ?= ceph-ansible
+DEPLOY_MODE ?= manager
+
 VERSION_CEPH ?= reef
 VERSION_MANAGER ?= latest
 VERSION_OPENSTACK ?= 2024.2
-
-CEPH_STACK ?= ceph-ansible
 
 # renovate: datasource=github-releases depName=opentofu/opentofu
 TOFU_VERSION ?= 1.9.0
@@ -102,7 +103,8 @@ bootstrap: setup create ## Bootstrap everything.
 	  -e ceph_version=$(VERSION_CEPH) \
 	  -e manager_version=$(VERSION_MANAGER) \
 	  -e openstack_version=$(VERSION_OPENSTACK) \
-	  -e ceph_stack=$(CEPH_STACK)
+	  -e ceph_stack=$(CEPH_STACK) \
+	  -e deploy_mode=$(DEPLOY_MODE)
 
 .PHONY: manager
 manager: setup bootstrap ## Deploy only the manager service.
@@ -113,6 +115,7 @@ manager: setup bootstrap ## Deploy only the manager service.
 	  deploy-manager
 
 .PHONY: baremetal
+baremetal: DEPLOY_MODE = baremetal
 baremetal: setup manager ## Deploy only baremetal services.
 	make -C terraform \
 	  CLOUD=$(CLOUD) \

--- a/ansible/manager-part-3.yml
+++ b/ansible/manager-part-3.yml
@@ -55,6 +55,12 @@
         line: "ara_server_mariadb_volume_type: tmpfs"
       when: "'export IS_ZUUL=true' in manager_vars"
 
+    - name: Add netbox_enable parameter
+      ansible.builtin.lineinfile:
+        path: /opt/configuration/environments/manager/configuration.yml
+        line: "netbox_enable: true"
+      when: "'export DEPLOY_MODE=baremetal' in manager_vars"
+
     # The correct package name is linux-generic-hwe-22.04 on Ubuntu 22.04
     # and linux-generic-hwe-24.04 on Ubuntu 24.04.
     - name: Install HWE kernel package on Ubuntu

--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -44,8 +44,6 @@ ara_server_traefik: true
 ##########################
 # netbox
 
-netbox_enable: true
-
 netbox_host: netbox.testbed.osism.xyz
 netbox_traefik: true
 netbox_api_url: "https://{{ netbox_host }}"

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -16,13 +16,13 @@ RESOURCE = openstack_networking_floatingip_v2.manager_floating_ip
 STATE = errored.tfstate
 
 CEPH_STACK ?= ceph-ansible
+DEPLOY_MODE ?= manager
+KOLLA_NAMESPACE ?= osism
+TEMPEST ?= false
+
 VERSION_CEPH ?= reef
 VERSION_MANAGER ?= latest
 VERSION_OPENSTACK ?= 2024.2
-
-KOLLA_NAMESPACE ?= osism
-
-TEMPEST ?= false
 
 APPLY_PARAMS = -auto-approve -parallelism=$(PARALLELISM)
 
@@ -66,6 +66,7 @@ init:
 	@echo "ceph_stack = \"$(CEPH_STACK)\"" >> $(CLOUD).auto.tfvars
 	@echo "ceph_version = \"$(VERSION_CEPH)\"" >> $(CLOUD).auto.tfvars
 	@echo "cloud_provider = \"$(OS_CLOUD)\"" >> $(CLOUD).auto.tfvars
+	@echo "deploy_mode= \"$(DEPLOY_MODE)\"" >> $(CLOUD).auto.tfvars
 	@echo "image_node_user = \"$(IMAGE_USERNAME)\"" >> $(CLOUD).auto.tfvars
 	@echo "image_user = \"$(IMAGE_USERNAME)\"" >> $(CLOUD).auto.tfvars
 	@echo "manager_version = \"$(VERSION_MANAGER)\"" >> $(CLOUD).auto.tfvars


### PR DESCRIPTION
Introduces DEPLOY_MODE variable to control netbox enablement based on deployment type. Netbox is now enabled only for baremetal deployments while remaining disabled for manager-only deployments.