### PR TITLE
Do not restart old manager service

### DIFF
--- a/scripts/deploy-manager.sh
+++ b/scripts/deploy-manager.sh
@@ -52,7 +52,11 @@ osism apply wait-for-connection -l testbed-nodes -e ireallymeanit=yes
 osism apply hddtemp
 
 # restart the manager services to update the /etc/hosts file
-sudo systemctl restart docker-compose@manager
+if [[ $(semver $MANAGER_VERSION 7.1.1) -ge 0 || $MANAGER_VERSION == "latest" ]]; then
+    sudo systemctl restart manager.service
+else
+    sudo systemctl restart docker-compose@manager
+fi
 
 # wait for manager service
 if [[ $CEPH_STACK == "ceph-ansible" ]]; then


### PR DESCRIPTION
Do not restart the old manager service `docker-compose@manager.service` on osism versions using the new `manager.service`.

This fixes a bug where applying the manager role would stop the manager service when trying to stop and disable the old manager service, which would be active due to the restart and issue a `docker-compose down`.