### PR TITLE
Use variables for redfish credentials in conductor.yml

### DIFF
--- a/environments/manager/files/conductor.yml
+++ b/environments/manager/files/conductor.yml
@@ -2,8 +2,8 @@
 ironic_parameters:
   driver: ipmi
   driver_info:
-    ipmi_username: admin
-    ipmi_password: password
+    ipmi_username: "{{ remote_board_username }}"
+    ipmi_password: "{{ remote_board_password }}"
     ipmi_address: "{{ remote_board_address }}"
     ipmi_port: 6230
     deploy_kernel: ironic-agent-kernel


### PR DESCRIPTION
Replace hardcoded username and password with Ansible variables remote_board_username and remote_board_password for better security.