### PR TITLE
terraform: remove local.tfvars.sample

### DIFF
--- a/terraform/environments/local.tfvars.sample
+++ b/terraform/environments/local.tfvars.sample
@@ -1,2 +1,0 @@
-flavor_node    = "2C-4GB-20GB"
-flavor_manager = "1C-2GB-10GB"


### PR DESCRIPTION
Avoid confusions. This file should not be used to create a new environment.

Related to osism/testbed#2746