### PR TITLE
Fix conditional in ceph ansible deploy

### DIFF
--- a/scripts/deploy/100-ceph-with-ansible.sh
+++ b/scripts/deploy/100-ceph-with-ansible.sh
@@ -15,8 +15,8 @@ if [[ $MANAGER_VERSION == "latest" && $CEPH_VERSION == "pacific" ]]; then
     sed -i "s/osism.commons.still_alive/community.general.yaml/" /opt/configuration/environments/ansible.cfg
 fi
 
-if [[ $(semver $MANAGER_VERSION 9.0.0) -lt 0 && $MANAGER_VERSION != "latest" && && $CEPH_VERSION == "reef" ]]; then
-    # The rgw zone was added in Ceph Reef in OSISM 9 and later
+if [[ $CEPH_VERSION == "octopus" || $CEPH_VERSION == "pacific" || $CEPH_VERSION == "quincy" ]]; then
+    # The rgw zone was added in ceph-ansible Reef
     sed -i '/  "client\.rgw\./{s#{{ rgw_zone }}\.##g}' environments/ceph/configuration.yml
 fi
 


### PR DESCRIPTION
The conditional for the RGW zone contained a superfluous `&&`. Additionally it is only required to check the ceph version and remove the RGW zone for versions < reef