### PR TITLE
Fix empty openstack_version when resolving from release repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,8 @@ bootstrap: setup create ## Bootstrap everything.
 	    BASE_CONTENT=$$(curl -sf "$$BASE_URL") || { echo "ERROR: Failed to fetch $$BASE_URL - release $(VERSION_MANAGER) may not exist on osism/release"; exit 1; }; \
 	    RESOLVED_CEPH=$$(echo "$$BASE_CONTENT" | grep "^ceph_version:" | sed 's/ceph_version:[[:space:]]*//;s/"//g'); \
 	    RESOLVED_OS=$$(echo "$$BASE_CONTENT" | grep "^openstack_version:" | sed 's/openstack_version:[[:space:]]*//;s/"//g'); \
+	    RESOLVED_CEPH="$${RESOLVED_CEPH:-$(VERSION_CEPH)}"; \
+	    RESOLVED_OS="$${RESOLVED_OS:-$(VERSION_OPENSTACK)}"; \
 	else \
 	    RESOLVED_CEPH="$(VERSION_CEPH)"; \
 	    RESOLVED_OS="$(VERSION_OPENSTACK)"; \

--- a/scripts/set-docker-registry.sh
+++ b/scripts/set-docker-registry.sh
@@ -13,10 +13,10 @@ sed -i "s#docker_registry_netbox: .*#docker_registry_netbox: ${DOCKER_REGISTRY}#
 
 if [[ "$DOCKER_REGISTRY" == "registry.osism.tech" ]]; then
     if [[ "$MANAGER_VERSION" == "latest" ]]; then
-        sed -i "s#docker_namespace: osism#docker_namespace: kolla#" /opt/configuration/inventory/group_vars/all/kolla.yml
+        /opt/configuration/scripts/set-kolla-namespace.sh kolla
     elif [[ $(semver $MANAGER_VERSION 10.0.0-0) -ge 0 ]]; then
-        sed -i "s#docker_namespace: osism#docker_namespace: kolla/release/$OPENSTACK_VERSION#" /opt/configuration/inventory/group_vars/all/kolla.yml
+        /opt/configuration/scripts/set-kolla-namespace.sh "kolla/release/$OPENSTACK_VERSION"
     else
-        sed -i "s#docker_namespace: osism#docker_namespace: kolla/release#" /opt/configuration/inventory/group_vars/all/kolla.yml
+        /opt/configuration/scripts/set-kolla-namespace.sh kolla/release
     fi
 fi

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -76,8 +76,8 @@ init:
 	    BASE_CONTENT=$$(curl -sf "$$BASE_URL") || { echo "ERROR: Failed to fetch $$BASE_URL - release $(VERSION_MANAGER) may not exist on osism/release"; exit 1; }; \
 	    RELEASE_CEPH=$$(echo "$$BASE_CONTENT" | grep "^ceph_version:" | sed 's/ceph_version:[[:space:]]*//;s/"//g'); \
 	    RELEASE_OS=$$(echo "$$BASE_CONTENT" | grep "^openstack_version:" | sed 's/openstack_version:[[:space:]]*//;s/"//g'); \
-	    echo "ceph_version = \"$$RELEASE_CEPH\"" >> $(CLOUD).auto.tfvars; \
-	    echo "openstack_version = \"$$RELEASE_OS\"" >> $(CLOUD).auto.tfvars; \
+	    echo "ceph_version = \"$${RELEASE_CEPH:-$(VERSION_CEPH)}\"" >> $(CLOUD).auto.tfvars; \
+	    echo "openstack_version = \"$${RELEASE_OS:-$(VERSION_OPENSTACK)}\"" >> $(CLOUD).auto.tfvars; \
 	else \
 	    echo "ceph_version = \"$(VERSION_CEPH)\"" >> $(CLOUD).auto.tfvars; \
 	    echo "openstack_version = \"$(VERSION_OPENSTACK)\"" >> $(CLOUD).auto.tfvars; \


### PR DESCRIPTION
The release repo's base.yml does not contain openstack_version or ceph_version fields, causing the grep to return empty and resulting in docker_namespace being set to "kolla/release/" without a version.

Fall back to user-provided VERSION_OPENSTACK/VERSION_CEPH when the release repo fields are missing. Also fix set-docker-registry.sh to use set-kolla-namespace.sh (the old sed matched "osism" but the default value is "kolla", so it never matched).

AI-assisted: Claude Code