### PR TITLE
Fix tempest script silently ignoring failures

### DIFF
--- a/scripts/check/302-openstack-with-tempest.sh
+++ b/scripts/check/302-openstack-with-tempest.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -x
 set -e
+set -o pipefail
 
 source /opt/manager-vars.sh
 


### PR DESCRIPTION
The _tempest() function pipes docker output through tee:

    docker run ... | tee -a /opt/tempest/$(date +%Y%m%d-%H%M).log

With set -e but without pipefail, bash uses the exit code of the last command in the pipeline (tee), which always succeeds. This means any failure in the docker/tempest command is silently ignored and the script exits 0.

This affects the nightly Zuul periodic-midnight tempest jobs, which currently report SUCCESS with zero tests actually executed.

Adding set -o pipefail ensures the pipeline returns the exit code of the leftmost failing command.

AI-assisted: Claude Code