### PR TITLE
Fix black 26.3.1 formatting

### DIFF
--- a/contrib/analyze-zuul-logs.py
+++ b/contrib/analyze-zuul-logs.py
@@ -49,7 +49,6 @@ except ImportError:
 
 import httpx
 
-
 # Known false positives - tasks that are expected to fail during initial deployment
 # These are filtered out from the failed_tasks list before analysis
 # Format: List of regex patterns that match task names or error messages


### PR DESCRIPTION
## Summary
- Reformat code to comply with black 26.3.1 stable style (updated in osism/zuul-jobs#180)

## Test plan
- [ ] python-black Zuul job passes