### PR TITLE
Rename repository from cfg-generics -> generics

### DIFF
--- a/gilt.yml
+++ b/gilt.yml
@@ -1,5 +1,5 @@
 ---
-- git: https://github.com/osism/cfg-generics.git
+- git: https://github.com/osism/generics.git
   version: main
   files:
     - src: environments/manager/images.yml


### PR DESCRIPTION
## Summary

- Update `gilt.yml` to clone from `https://github.com/osism/generics.git` instead of the old `osism/cfg-generics` URL.
- Both URLs currently resolve to the same repository (GitHub 301-redirects `cfg-generics` to `generics`), so no behavioral change is expected.
- Brings testbed in line with `metalbox` and `cloud-in-a-box`, which already reference the canonical URL. Mirrors the upstream rename in osism/generics#560.

## Test plan

- [ ] `gilt overlay` pulls from `osism/generics.git` and produces the same rendered files as before.