### PR TITLE
Baremetal: Allow SW-RAID deployments

### DIFF
--- a/environments/custom/files/baremetal-tenks-override.yml
+++ b/environments/custom/files/baremetal-tenks-override.yml
@@ -8,12 +8,13 @@ node_types:
   # The type name.
   type0:
     # The amount of RAM, in mebibytes.
-    memory_mb: 4096
+    memory_mb: 8192
     # The number of virtual CPUs.
     vcpus: 2
     # A list of volumes, each with a capacity.
     volumes:
-      - capacity: 5GB
+      - capacity: 8GB
+      - capacity: 8GB
     # A list of physical network names to connect to. These physical network
     # names should be keyed in `physnet_mappings` in each hypervisor's host
     # vars.

--- a/environments/custom/templates/baremetal-netbox-device.yml.j2
+++ b/environments/custom/templates/baremetal-netbox-device.yml.j2
@@ -11,6 +11,12 @@
         driver_info:
           ipmi_address: {{ oob_address }}
           ipmi_port: {{ oob_port }}
+        target_raid_config:
+          logical_disks:
+            - size_gb: MAX
+              raid_level: "1"
+              is_root_volume: true
+              controller: software
     tags:
       - managed-by-osism
       - managed-by-ironic

--- a/environments/kolla/files/overlays/ironic/ironic-conductor.conf
+++ b/environments/kolla/files/overlays/ironic/ironic-conductor.conf
@@ -2,6 +2,9 @@
 enabled_network_interfaces = noop
 default_network_interface = noop
 
+enabled_raid_interfaces = agent,no-raid
+default_raid_interface = agent
+
 [pxe]
 tftp_server = {{ ironic_tftp_listen_address }}
 # NOTE: set kernel cmdline for IPA image


### PR DESCRIPTION
Add an addtitional disk to simulated baremetal nodes and configure ironic for SW-RAID deployment.
Add a software `target_raid_config` to the nodes netbox template. To deploy with software RAID upload and reference an MDRAID capable image. The standard Cirros image will start from software RAID deployments, but cannot assemble it, because it has no support for it.