### PR TITLE
workflow: rename remaining cfg-generics URLs

### DIFF
--- a/.github/workflows/update-manager-images.yml
+++ b/.github/workflows/update-manager-images.yml
@@ -26,8 +26,8 @@ jobs:
             pip3 install jinja2
             pip3 install requests
             pip3 install pyyaml
-            curl -o images.yml https://raw.githubusercontent.com/osism/cfg-generics/main/environments/manager/images.yml
-            curl -o render-images.py https://raw.githubusercontent.com/osism/cfg-generics/main/src/render-images.py
+            curl -o images.yml https://raw.githubusercontent.com/osism/generics/main/environments/manager/images.yml
+            curl -o render-images.py https://raw.githubusercontent.com/osism/generics/main/src/render-images.py
             python3 render-images.py
             rm -f render-images.py
             mv images.yml environments/manager/images.yml


### PR DESCRIPTION
## Summary
- Follow-up to #2876: two `raw.githubusercontent.com` URLs in `.github/workflows/update-manager-images.yml` were missed by the rename and still fetched `images.yml` and `render-images.py` from `osism/cfg-generics`.
- The old URLs still resolve via GitHub's rename alias, so the scheduled job wasn't broken — this is just for consistency with the rest of the repo.

## Test plan
- [ ] CI lint passes on the workflow change
- [ ] Next scheduled `Update manager images` run (or a manual `workflow_dispatch`) successfully fetches both files from `osism/generics` and opens the usual chore PR