### PR TITLE
Fix stale kolla namespace on upgrade-manager

### DIFF
--- a/scripts/set-kolla-namespace.sh
+++ b/scripts/set-kolla-namespace.sh
@@ -2,6 +2,18 @@
 set -x
 set -e
 
+SYNC=false
+if [[ "$1" == "--sync" ]]; then
+    SYNC=true
+    shift
+fi
+
 NAMESPACE=${1:-osism}
 
 sed -i "s#docker_namespace: .*#docker_namespace: ${NAMESPACE}#g" /opt/configuration/inventory/group_vars/all/kolla.yml
+
+# --sync makes the new namespace visible to the next `osism apply` immediately,
+# instead of waiting for the inventory-reconciler's periodic tick.
+if [[ "$SYNC" == "true" ]]; then
+    osism sync inventory
+fi

--- a/scripts/upgrade-manager.sh
+++ b/scripts/upgrade-manager.sh
@@ -89,5 +89,5 @@ osism apply facts
 
 if [[ $MANAGER_VERSION != "latest" && $(semver $MANAGER_VERSION 10.0.0-0) -ge 0 ]]; then
     OPENSTACK_VERSION=$(docker inspect --format '{{ index .Config.Labels "de.osism.release.openstack"}}' kolla-ansible)
-    /opt/configuration/scripts/set-kolla-namespace.sh "kolla/release/$OPENSTACK_VERSION"
+    /opt/configuration/scripts/set-kolla-namespace.sh --sync "kolla/release/$OPENSTACK_VERSION"
 fi


### PR DESCRIPTION
## Summary

- `upgrade-manager.sh` switches `docker_namespace` to `kolla/release/<openstack_version>` and then runs further `osism apply` steps. The apply reads `/inventory/fast/`, which is only refreshed on the inventory-reconciler's periodic tick (default 600s), so it sees the old namespace and the `Restart fluentd container` handler hits a 404 on `registry.osism.tech/kolla/release/fluentd:<tag>` instead of `registry.osism.tech/kolla/release/<openstack_version>/fluentd:<tag>`. This has caused `testbed-upgrade-stable-ubuntu-24.04` and `testbed-upgrade-stable-next-ubuntu-24.04` to fail.
- Add an opt-in `--sync` flag to `scripts/set-kolla-namespace.sh` that runs `osism sync inventory` after the sed edit, and pass it at the `upgrade-manager.sh` call site that needs the new namespace visible before the next apply. Other call sites don't race the reconciler and keep the bare form.

## Impact

Two Zuul jobs have been failing on every hit:

- `testbed-upgrade-stable-next-ubuntu-24.04` — **no SUCCESS in the entire ~4.5-month queryable log window**. First observable HIT: [`b816310b`](https://logs.services.osism.tech/b81/osism/b816310b0f7b4b98954ac944db0f7ad4/) (2025-12-14); the three builds immediately before it were also FAILUREs but their logs have been purged, so the actual regression may be earlier.
- `testbed-upgrade-stable-ubuntu-24.04` — first HIT in available history: [`78cb2acd`](https://logs.services.osism.tech/78c/osism/78cb2acde7f44d9b93a4897b499fbfbd/) (2026-04-01); this job's log retention only reaches 2026-03-31.

Recent reproductions:

- [`377188db`](https://zuul.services.osism.tech/t/osism/build/377188db0c3b45a887b4299ebc0ee161) (2026-04-24, upgrade-stable-next) — 6/6 nodes failed on `registry.osism.tech/kolla/release/fluentd:2025.1` → 404.
- [`96a11561`](https://logs.services.osism.tech/96a/osism/96a1156117a546f694621d07f3c1b0cf/) (2026-04-23, upgrade-stable-next).
- [`56275797`](https://logs.services.osism.tech/562/osism/5627579777374508ad509cbf328c0008/) (2026-04-23, upgrade-stable).

The `Restart fluentd container` handler fails on every node. Fluentd is simply the first kolla image the handler run touches — cron, kolla-toolbox, and rabbitmq would 404 identically at their `:<new-tag>` under the bare `kolla/release/<name>` namespace, but the run aborts before reaching them.

## Test plan

- [x] Verified on a live testbed: starting from `MANAGER_VERSION=latest` (namespace `kolla`), ran `upgrade-manager 10.0.0`. The fixed site invoked `set-kolla-namespace.sh --sync kolla/release/2025.1`, `osism sync inventory` ran, and both `/opt/configuration/inventory/group_vars/all/kolla.yml` and the reconciler's `fast/group_vars/all/kolla.yml` showed `docker_namespace: kolla/release/2025.1` immediately after the script finished — no reconciler-tick wait.
- [ ] `testbed-upgrade-stable-ubuntu-24.04` goes green.
- [ ] `testbed-upgrade-stable-next-ubuntu-24.04` goes green.