### PR TITLE
Fix namespace sync for latest manager upgrades

### DIFF
--- a/scripts/upgrade-manager.sh
+++ b/scripts/upgrade-manager.sh
@@ -87,7 +87,11 @@ fi
 # refresh facts
 osism apply facts
 
-if [[ $MANAGER_VERSION != "latest" && $(semver $MANAGER_VERSION 10.0.0-0) -ge 0 ]]; then
-    OPENSTACK_VERSION=$(docker inspect --format '{{ index .Config.Labels "de.osism.release.openstack"}}' kolla-ansible)
-    /opt/configuration/scripts/set-kolla-namespace.sh --sync "kolla/release/$OPENSTACK_VERSION"
+if [[ $KOLLA_NAMESPACE == "kolla/release" ]]; then
+    if [[ $MANAGER_VERSION != "latest" || $OPENSTACK_VERSION == "skip" ]]; then
+        OPENSTACK_VERSION=$(docker inspect --format '{{ index .Config.Labels "de.osism.release.openstack"}}' kolla-ansible)
+    fi
+    if [[ $MANAGER_VERSION == "latest" || $(semver $MANAGER_VERSION 10.0.0-0) -ge 0 ]]; then
+        /opt/configuration/scripts/set-kolla-namespace.sh --sync "kolla/release/$OPENSTACK_VERSION"
+    fi
 fi


### PR DESCRIPTION
## Summary

Commit [fbb20b13](https://github.com/osism/testbed/commit/fbb20b13373f687f1ce213b6954a666e3f9bcc2d) fixed the stale kolla namespace for pinned stable upgrades (`MANAGER_VERSION != "latest" && semver >= 10.0.0`). That fix is confirmed working: build [69ad24d7](https://zuul.services.osism.tech/t/osism/build/69ad24d733aa450da61f045d3e7bc0d9) (`testbed-upgrade-stable-ubuntu-24.04`, `manager_version_next: 10.0.0`) completed the `Restart fluentd container` handler successfully on all seven nodes — no success had been recorded in the entire available log history before this. The build then failed on an unrelated Ceph monitor quorum timeout, a step that was never reached with the stale namespace in place.

`testbed-upgrade-stable-next-ubuntu-24.04` uses `manager_version_next: latest`, which causes the guard to evaluate to false — the `--sync` call is never reached and the registry miss persists.

This PR restructures the block under a single `kolla/release` namespace guard with two sequential checks: resolve `OPENSTACK_VERSION` from the container label when the parameter cannot be used as-is, then sync when the manager version qualifies (`latest` or pinned >= 10.0.0). Also handles `OPENSTACK_VERSION=skip` correctly (inspects label rather than writing `kolla/release/skip`).

## Test plan

- [ ] Verify `testbed-upgrade-stable-next-ubuntu-24.04` passes the `Restart fluentd container` handler after this merges
- [ ] Verify `testbed-upgrade-stable-ubuntu-24.04` continues to pass (confirmed fixed by fbb20b13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)