### PR TITLE
deploy: replace fixed delays with event-driven waits for SSH auth and docker

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -217,9 +217,23 @@
         delay: 10
         timeout: 300
 
-    - name: Wait a little longer for the manager so that everything is ready
-      ansible.builtin.pause:
-        seconds: 60
+    - name: Wait until docker is available on the manager
+      ansible.builtin.command:
+        cmd: >-
+          ssh
+          -i {{ terraform_path }}/.id_rsa.{{ cloud }}
+          -o BatchMode=yes
+          -o ConnectTimeout=5
+          -o PreferredAuthentications=publickey
+          -o StrictHostKeyChecking=yes
+          -o UserKnownHostsFile={{ ansible_user_dir }}/.ssh/known_hosts
+          dragon@{{ manager_host }}
+          docker info
+      register: manager_ssh_auth
+      until: manager_ssh_auth.rc == 0
+      retries: 60
+      delay: 5
+      changed_when: false
 
     - name: Deploy manager + bootstrap nodes
       ansible.builtin.command:

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -125,14 +125,32 @@
         delay: 10
         timeout: 300
 
-    - name: Wait a little longer for the manager so that everything is ready
-      ansible.builtin.pause:
-        seconds: 60
-
     - name: Fetch manager ssh hostkey
       ansible.builtin.shell: "ssh-keyscan {{ manager_host }} >> {{ ansible_user_dir }}/.ssh/known_hosts"
+      register: manager_ssh_hostkey
+      until: manager_ssh_hostkey.rc == 0
+      retries: 60
+      delay: 5
       changed_when: true
       no_log: true
+
+    - name: Wait until ssh public key authentication to the manager works
+      ansible.builtin.command:
+        cmd: >-
+          ssh
+          -i {{ terraform_path }}/.id_rsa.{{ cloud }}
+          -o BatchMode=yes
+          -o ConnectTimeout=5
+          -o PreferredAuthentications=publickey
+          -o StrictHostKeyChecking=yes
+          -o UserKnownHostsFile={{ ansible_user_dir }}/.ssh/known_hosts
+          {{ image_username }}@{{ manager_host }}
+          true
+      register: manager_ssh_auth
+      until: manager_ssh_auth.rc == 0
+      retries: 60
+      delay: 5
+      changed_when: false
 
     - name: Get ssh keypair from terraform environment
       ansible.builtin.shell:


### PR DESCRIPTION
Bootstrap used two fixed 60-second delays as timing guards: one after detecting port 22 open, and one after the manager reboot. Fixed sleeps are neither reliable nor efficient — they can still be beaten by a slow VM and always add latency to a fast one.

This replaces both delays with active polls:

- **SSH auth** (`wait for manager ssh auth`): polls `ssh -o BatchMode=yes … true` with the Terraform key and image user until it succeeds. Also adds retry to `ssh-keyscan` to handle early sshd startup. The race this addresses was observed twice in testing against an OpenStack deployment (once at the keyscan step, once at the first Ansible connection), confirming the fixed delay was not sufficient protection.
- **Docker** (`wait for docker after manager reboot`): polls `docker info` over SSH as the `dragon` user after the manager reboot.

The second guard in particular may be incomplete — the original delay could have been covering more than docker readiness, but the old code gives no indication of what else it was waiting for. A probabilistic race cannot be proven correct by any finite number of successful runs, but these guards target concrete, observable conditions rather than guessing at timing. Local testing confirms both conditions resolve promptly with no failures observed.