### PR TITLE
check: collect infrastructure failures

### DIFF
--- a/scripts/check/200-infrastructure.sh
+++ b/scripts/check/200-infrastructure.sh
@@ -19,47 +19,67 @@ fi
 
 pushd /opt/configuration/contrib > /dev/null
 
+failures=0
+
+run_check() {
+    local name="$1"
+
+    shift
+
+    if ! "$@"; then
+        echo
+        echo "ERROR: $name check failed"
+        failures=$((failures + 1))
+    fi
+}
+
 echo
 echo "# Status of Elasticsearch"
 echo
 
-bash nagios-plugins/check_elasticsearch -H api-int.testbed.osism.xyz -s
+run_check "Elasticsearch" bash nagios-plugins/check_elasticsearch -H api-int.testbed.osism.xyz -s
 
 echo
 echo "# Status of MariaDB"
 echo
 
 if [[ $(semver $MANAGER_VERSION 10.0.0-0) -ge 0 || $MANAGER_VERSION == "latest" ]]; then
-    osism status database
+    run_check "MariaDB" osism status database
 else
     MARIADB_USER=root_shard_0
-    bash nagios-plugins/check_galera_cluster -u $MARIADB_USER -p password -H api-int.testbed.osism.xyz -c 1
+    run_check "MariaDB" bash nagios-plugins/check_galera_cluster -u $MARIADB_USER -p password -H api-int.testbed.osism.xyz -c 1
 fi
 
 echo
 echo "# Status of Prometheus"
 echo
 
-curl -s https://api-int.testbed.osism.xyz:9091/-/healthy
-curl -s https://api-int.testbed.osism.xyz:9091/-/ready
+run_check "Prometheus healthy" curl -s https://api-int.testbed.osism.xyz:9091/-/healthy
+run_check "Prometheus ready" curl -s https://api-int.testbed.osism.xyz:9091/-/ready
 
 echo
 echo "# Status of RabbitMQ"
 echo
 
 if [[ $(semver $MANAGER_VERSION 10.0.0-0) -ge 0 || $MANAGER_VERSION == "latest" ]]; then
-    osism status messaging
+    run_check "RabbitMQ" osism status messaging
 else
-    perl nagios-plugins/check_rabbitmq_cluster --ssl 1 -H api-int.testbed.osism.xyz -u openstack -p password
+    run_check "RabbitMQ" perl nagios-plugins/check_rabbitmq_cluster --ssl 1 -H api-int.testbed.osism.xyz -u openstack -p password
 fi
 
 echo
 echo "# Status of Redis"
 echo
 
-/usr/lib/nagios/plugins/check_tcp -H 192.168.16.10 -p 6379 -A -E -s 'AUTH QHNA1SZRlOKzLADhUd5ZDgpHfQe6dNfr3bwEdY24\r\nPING\r\nINFO replication\r\nQUIT\r\n' -e 'PONG' -e 'role:master' -e 'slave0:ip=192.168.16.1' -e',port=6379' -j
+run_check "Redis" /usr/lib/nagios/plugins/check_tcp -H 192.168.16.10 -p 6379 -A -E -s 'AUTH QHNA1SZRlOKzLADhUd5ZDgpHfQe6dNfr3bwEdY24\r\nPING\r\nINFO replication\r\nQUIT\r\n' -e 'PONG' -e 'role:master' -e 'slave0:ip=192.168.16.1' -e',port=6379' -j
 
 popd > /dev/null
+
+if [[ $failures -gt 0 ]]; then
+    echo
+    echo "ERROR: $failures infrastructure status check(s) failed"
+    exit 1
+fi
 
 echo
 echo "# Create backup of MariaDB database"


### PR DESCRIPTION
The infrastructure check script stopped at the first failing status command because it runs with set -e. This hid later failures in the same check group. In particular, an OpenSearch warning could prevent the MariaDB/Galera check from running, so a separate Galera collation failure was only visible on runs where OpenSearch was healthy.

Add a small run_check helper and use it for the infrastructure status checks. Each check still prints its normal output, but failures are recorded and the script continues through the remaining status checks. After Redis has been checked, the script exits non-zero if any status check failed.

Keep the MariaDB backup after the aggregated failure check. That preserves the previous behavior that backup is only attempted when all infrastructure status checks passed.

AI-assisted: Codex/GPT