### PR TITLE
deploy: read kolla namespace version from container label

### DIFF
--- a/scripts/deploy/000-manager.sh
+++ b/scripts/deploy/000-manager.sh
@@ -82,7 +82,8 @@ osism apply squid
 
 if [[ $MANAGER_VERSION != "latest" ]]; then
   if [[ $(semver $MANAGER_VERSION 10.0.0-0) -ge 0 ]]; then
-    /opt/configuration/scripts/set-kolla-namespace.sh "kolla/release/$OPENSTACK_VERSION"
+    KOLLA_OS_VERSION=$(docker inspect --format '{{ index .Config.Labels "de.osism.release.openstack"}}' kolla-ansible)
+    /opt/configuration/scripts/set-kolla-namespace.sh "kolla/release/$KOLLA_OS_VERSION"
   else
     /opt/configuration/scripts/set-kolla-namespace.sh kolla/release
   fi


### PR DESCRIPTION
## Summary

- `000-manager.sh` was setting `docker_namespace` to `kolla/release/$OPENSTACK_VERSION` for stable releases >= 10.0.0, where `$OPENSTACK_VERSION` came from the Makefile fallback `VERSION_OPENSTACK=2024.2`
- `release/10.0.0/base.yml` intentionally omits `openstack_version` (the versioned kolla namespace is kolla-specific, not a general release parameter), so the Makefile falls back to `2024.2` — a namespace that has never been populated
- The correct version for OSISM 10.0.0 is 2025.1; `kolla/release/2025.1/` is fully populated with release-tagged images
- Fix: read the OpenStack version from the running kolla-ansible container's `de.osism.release.openstack` label via `docker inspect`, matching the pattern already used in `upgrade-manager.sh`

## Test plan

- [ ] `testbed-deploy-stable-in-a-nutshell-ubuntu-24.04` (label pipeline) deploys successfully
- [ ] `testbed-deploy-stable-in-a-nutshell-with-tempest-ubuntu-24.04` (periodic-midnight) stops timing out

🤖 Generated with [Claude Code](https://claude.ai/claude-code)