### PR TITLE
check: use mariadb-client instead of mysql-client

### DIFF
--- a/scripts/check/200-infrastructure.sh
+++ b/scripts/check/200-infrastructure.sh
@@ -4,14 +4,7 @@ set -e
 
 source /opt/manager-vars.sh
 
-# Ubuntu
-source /etc/os-release
-if [[ "$ID" == "ubuntu" ]]; then
-    packages='libmonitoring-plugin-perl libwww-perl libjson-perl monitoring-plugins-basic mysql-client'
-# Debian
-elif [[ "$ID" == "debian" ]]; then
-    packages='libmonitoring-plugin-perl libwww-perl libjson-perl monitoring-plugins-basic mariadb-client'
-fi
+packages='libmonitoring-plugin-perl libwww-perl libjson-perl monitoring-plugins-basic mariadb-client'
 
 if ! dpkg -s $packages >/dev/null 2>&1; then
     sudo apt-get install -y $packages >/dev/null 2>&1


### PR DESCRIPTION
## Summary

- On Ubuntu, `mysql-client` resolves to the MySQL 8.0 client, which sends `utf8mb4_0900_ai_ci` in SQL query packets. MariaDB rejects that collation with `ERROR 1273 (HY000)` on versions before 11.4.5; kolla 2024.2 ships MariaDB 10.11.
- The `check_galera_cluster` nagios plugin's first real SQL query fails silently, leaving `wsrep_cluster_state_uuid` empty and causing the plugin to report `CRITICAL: node is not part of a cluster` even when the cluster is healthy.
- Replace the Ubuntu/Debian split (`mysql-client` / `mariadb-client`) with `mariadb-client` unconditionally. `mariadb-client` provides a `mysql` compatibility symlink, so the `check_executable mysql` check in the plugin continues to work. The package is available in Ubuntu universe on 20.04, 22.04, and 24.04.

## Test plan

- [x] Deployed testbed at `--version-manager 9.5.0` (so `MANAGER_VERSION=9.5.0` in `/opt/manager-vars.sh`, which triggers the `check_galera_cluster` path in `200-infrastructure.sh` rather than `osism status database`)
- [x] Post-upgrade `check.sh` ran `check_galera_cluster` with `mariadb-client` installed — returned `OK: number of NODES = 3` with no collation error
- [x] Overall upgrade run status: success

🤖 Generated with [Claude Code](https://claude.com/claude-code)