### PR TITLE
k3s: guard version test against non-semver manager_version

### DIFF
--- a/inventory/group_vars/testbed-nodes.yml
+++ b/inventory/group_vars/testbed-nodes.yml
@@ -100,9 +100,14 @@ cilium_bgp_neighbors:
 # kubevip -> frr
 # osism-ansible < 9.0.0 uses bgppeers (old format); osism-kubernetes >= 9.0.0 uses bgp_peers.
 # Only pass the list for 9.0.0+; 8.x falls back to kube_vip_bgp_peeraddress/kube_vip_bgp_peeras.
+# The match('^[0-9]') guard is required because in 9.x the inventory reconciler sets
+# manager_version to a date-based container tag (e.g. v0.20251130.0) rather than the OSISM
+# release semver; LooseVersion cannot compare 'v...' against a numeric version and raises a
+# TypeError.  Non-semver values always indicate a 9.x+ deployment, so they take the else branch.
 kube_vip_bgp_peers: >-
   {{ [] if (manager_version is defined
             and manager_version != 'latest'
+            and manager_version is match('^[0-9]')
             and manager_version is version('9.0.0', '<'))
      else [{'peer_address': '192.168.128.5', 'peer_asn': 64512}] }}
 


### PR DESCRIPTION
## Summary

- Commit `a46cdd84` introduced `manager_version is version('9.0.0', '<')` in the `kube_vip_bgp_peers` template without guarding against non-semver version strings
- For upgrade/update jobs that start from a semver manager version (e.g. `9.5.0`), the inventory reconciler overrides `manager_version` to the actual container image tag (e.g. `v0.20260322.0`)
- LooseVersion splits `v0.20260322.0` into `['v', 20260322, 0]`; comparing `'v' < 9` raises a Python TypeError, manifesting as `"Version comparison failed: '<' not supported between instances of 'str' and 'int'"` in `k3s_server` argspec validation
- Adds `manager_version is match('^[0-9]')` guard so non-digit-starting strings (date-based container tags) short-circuit to the else branch (correct 9.x+ behaviour)

## Impact

Fixes three midnight CI failures on `osism/testbed` (2026-05-20):
- `testbed-update-stable-current-ubuntu-24.04`
- `testbed-upgrade-stable-next-ubuntu-24.04`
- `testbed-upgrade-stable-ubuntu-24.04`

## Test plan

- [ ] CI midnight run after merge should show these three jobs passing the k3s deploy step
- [ ] `latest` deployments unaffected: `manager_version != 'latest'` still short-circuits before the version test

🤖 Generated with [Claude Code](https://claude.com/claude-code)