### PR TITLE
wireguard: add controller-side connectivity test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,13 @@ vpn-wireguard-config: setup ## Get the configuration for the wireguard vpn tunne
 	  ENVIRONMENT=$(ENVIRONMENT) \
 	  vpn-wireguard-config
 
+.PHONY: test-wireguard
+test-wireguard: setup ## Test WireGuard VPN connectivity to the testbed.
+	@make -C terraform \
+	  CLOUD=$(CLOUD) \
+	  ENVIRONMENT=$(ENVIRONMENT) \
+	  test-wireguard
+
 .PHONY: vpn-sshuttle
 vpn-sshuttle: setup ## Establish a sshuttle vpn tunnel.
 	@make -C terraform \

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -198,6 +198,7 @@
             -e terraform_environment={{ _terraform_environment }} \
             -e repo_path={{ repo_path }} \
             -e manager_version={{ _manager_version }} \
+            {{ ('-e testbed_src=' + testbed_src) if testbed_src is defined and testbed_src else '' }} \
             manager-part-1.yml | tee -a ansible-manager-part-1.log
       args:
         executable: /bin/bash
@@ -268,6 +269,15 @@
     - name: Run checks
       ansible.builtin.command:
         cmd: "ssh -i {{ terraform_path }}/.id_rsa.{{ cloud }} dragon@{{ manager_host }} /opt/configuration/scripts/check.sh"
+      when:
+        - not manual_deploy | bool
+        - run_checks | bool
+      changed_when: true
+
+    - name: Test WireGuard connectivity
+      ansible.builtin.command:
+        chdir: "{{ terraform_path }}"
+        cmd: make CLOUD={{ cloud }} WIREPROXY={{ ansible_user_dir }}/wireproxy test-wireguard
       when:
         - not manual_deploy | bool
         - run_checks | bool

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -277,7 +277,7 @@
     - name: Test WireGuard connectivity
       ansible.builtin.command:
         chdir: "{{ terraform_path }}"
-        cmd: make CLOUD={{ cloud }} WIREPROXY={{ ansible_user_dir }}/wireproxy test-wireguard
+        cmd: make CLOUD={{ cloud }} TERRAFORM={{ terraform_binary }} WIREPROXY={{ ansible_user_dir }}/wireproxy test-wireguard
       when:
         - not manual_deploy | bool
         - run_checks | bool

--- a/playbooks/pre.yml
+++ b/playbooks/pre.yml
@@ -10,8 +10,10 @@
     basepath: "{{ ansible_user_dir }}/src/{{ repositories['testbed']['path'] }}"
     terraformbase_path: "{{ ansible_user_dir }}/src/{{ repositories['terraform-base']['path'] }}"
     terraform_path: "{{ basepath }}/terraform"
-    opentofu_version: v1.11.5 # renovate: datasource=github-releases depName=opentofu/opentofu
+    opentofu_version: v1.11.5  # renovate: datasource=github-releases depName=opentofu/opentofu
     opentofu_download_url: "https://github.com/opentofu/opentofu/releases/download/{{ opentofu_version }}/tofu_{{ opentofu_version[1:] }}_linux_amd64.zip"
+    wireproxy_version: v1.1.2  # renovate: datasource=github-releases depName=pufferffish/wireproxy
+    wireproxy_download_url: "https://github.com/pufferffish/wireproxy/releases/download/{{ wireproxy_version }}/wireproxy_linux_amd64.tar.gz"
 
   tasks:
     - name: Set cloud fact (Zuul deployment)
@@ -39,6 +41,14 @@
         remote_src: true
         include:
           - tofu
+
+    - name: Extract wireproxy binary
+      ansible.builtin.unarchive:
+        src: "{{ wireproxy_download_url }}"
+        dest: "{{ ansible_user_dir }}"
+        remote_src: true
+        include:
+          - wireproxy
 
     # we run local synchronisation here
     - name: Sync terraform blueprint  # noqa: command-instead-of-module

--- a/scripts/test-wireguard.sh
+++ b/scripts/test-wireguard.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Run on the controller after fetching the WireGuard config:
+#
+#   make vpn-wireguard-config
+#   bash scripts/test-wireguard.sh terraform/wg-<cloud>.conf
+#
+# Or use: make test-wireguard  (handles config download automatically)
+#
+# Requires wireproxy in PATH or WIREPROXY env var pointing to the binary.
+
+set -euo pipefail
+
+WG_CONF="${1:?usage: $0 <wg-config-file>}"
+WIREPROXY="${WIREPROXY:-wireproxy}"
+
+if ! command -v "${WIREPROXY}" >/dev/null 2>&1; then
+    echo "ERROR: wireproxy not found (WIREPROXY=${WIREPROXY})"
+    echo "  Install from https://github.com/pufferffish/wireproxy/releases"
+    exit 1
+fi
+
+SOCKS_PORT=1080
+SOCKS_ADDR="127.0.0.1:${SOCKS_PORT}"
+tmpconf=$(mktemp)
+wireproxy_pid=""
+
+cleanup() {
+    [[ -n "${wireproxy_pid}" ]] && kill "${wireproxy_pid}" 2>/dev/null || true
+    rm -f "${tmpconf}"
+}
+trap cleanup EXIT
+
+# Convert wg-quick config to wireproxy config:
+# - strip MTU and DNS (wg-quick-specific, not supported by wireproxy)
+# - ensure Address has a prefix length (wireproxy requires it)
+# - append [Socks5] section
+sed \
+    -e '/^MTU\s*=/d' \
+    -e '/^DNS\s*=/d' \
+    -e 's/^\(Address\s*=\s*[0-9.]*\)$/\1\/32/' \
+    "${WG_CONF}" > "${tmpconf}"
+printf '\n[Socks5]\nBindAddress = %s\n' "${SOCKS_ADDR}" >> "${tmpconf}"
+
+"${WIREPROXY}" -c "${tmpconf}" >/dev/null 2>&1 &
+wireproxy_pid=$!
+
+# Wait for the SOCKS5 listener to be ready (up to 10 s)
+for _ in $(seq 1 20); do
+    { true < /dev/tcp/127.0.0.1/"${SOCKS_PORT}"; } 2>/dev/null && break
+    sleep 0.5
+done
+
+failures=0
+
+check() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        printf "PASS  %s\n" "${desc}"
+    else
+        printf "FAIL  %s\n" "${desc}"
+        failures=$((failures + 1))
+    fi
+}
+
+echo "WireGuard gateway connectivity"
+echo
+
+check "Keystone 192.168.16.254:5000" \
+    curl -sk --socks5 "${SOCKS_ADDR}" --max-time 5 \
+        https://192.168.16.254:5000/v3
+
+echo
+if [[ ${failures} -gt 0 ]]; then
+    echo "FAILED (${failures})"
+    exit 1
+fi
+echo "OK"

--- a/scripts/test-wireguard.sh
+++ b/scripts/test-wireguard.sh
@@ -46,6 +46,7 @@ wireproxy_pid=$!
 
 # Wait for the SOCKS5 listener to be ready (up to 10 s)
 for _ in $(seq 1 20); do
+    kill -0 "${wireproxy_pid}" 2>/dev/null || { echo "ERROR: wireproxy exited unexpectedly" >&2; exit 1; }
     { true < /dev/tcp/127.0.0.1/"${SOCKS_PORT}"; } 2>/dev/null && break
     sleep 0.5
 done

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -9,6 +9,7 @@ IMAGE_USERNAME = ubuntu
 
 OPENSTACK = openstack
 TERRAFORM ?= tofu
+WIREPROXY ?= wireproxy
 export TF_CLI_ARGS ?= -no-color
 
 PARALLELISM = 10
@@ -209,6 +210,10 @@ vpn-wireguard: .MANAGER_ADDRESS.$(CLOUD) .id_rsa.$(CLOUD) vpn-wireguard-config
 	@$(OPEN_CMD) "https://osism.tech/docs/guides/other-guides/testbed#webinterfaces"
 	@read -p "STOP?" CONT
 	sudo wg-quick down $(PWD)/wg-$(CLOUD).conf
+
+.PHONY: test-wireguard
+test-wireguard: vpn-wireguard-config
+	@WIREPROXY=$(WIREPROXY) bash $(CURDIR)/../scripts/test-wireguard.sh $(PWD)/wg-$(CLOUD).conf
 
 .PHONY: scp
 scp: .MANAGER_ADDRESS.$(CLOUD) .id_rsa.$(CLOUD)


### PR DESCRIPTION
Adds a controller-side WireGuard connectivity test that runs without
root or a kernel tunnel.  wireproxy brings up a SOCKS5 listener using
the downloaded client config; the test probes Keystone through it and
tears down on exit.

## Changes

- `scripts/test-wireguard.sh` — new script using wireproxy
- `terraform/Makefile` — `WIREPROXY` variable, `test-wireguard` target
- `Makefile` — top-level `test-wireguard` target
- `playbooks/pre.yml` — installs wireproxy from a pinned GitHub release (same pattern as tofu, Renovate-managed)
- `playbooks/deploy.yml` — runs `make test-wireguard` from the controller after manager-side checks

## Dependency

Requires osism/ansible-collection-services#2086 (WireGuard role: enable
ip_forward and MASQUERADE).  The test will fail without that fix because
forwarded packets are dropped by Neutron anti-spoofing.

## Test plan

- [ ] osism/ansible-collection-services#2086 merged
- [ ] CI deploy job passes with `test-wireguard` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)