### PR TITLE
deploy: capture manager console log on ssh fail

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -12,6 +12,9 @@
     ansible_playbook: ~/venv/bin/ansible-playbook
     basepath: "{{ ansible_user_dir }}/src/{{ repositories['testbed']['path'] }}"
     manager_address_file: "{{ terraform_path }}/.MANAGER_ADDRESS.{{ cloud }}"
+    # Nova instance name of the manager; override if the terraform "prefix"
+    # var is changed from its "testbed" default.
+    manager_server_name: testbed-manager
     repo_path: "{{ ansible_user_dir }}/src/{{ repository_server }}"
 
     manual_create: false
@@ -117,40 +120,74 @@
         - services
       changed_when: true
 
-    - name: Wait up to 300 seconds for port 22 to become open and contain "OpenSSH"
-      ansible.builtin.wait_for:
-        port: 22
-        host: "{{ manager_host }}"
-        search_regex: OpenSSH
-        delay: 10
-        timeout: 300
+    - name: Ensure the manager is reachable and authenticates over SSH
+      block:
+        - name: Wait up to 300 seconds for port 22 to become open and contain "OpenSSH"
+          ansible.builtin.wait_for:
+            port: 22
+            host: "{{ manager_host }}"
+            search_regex: OpenSSH
+            delay: 10
+            timeout: 300
 
-    - name: Fetch manager ssh hostkey
-      ansible.builtin.shell: "ssh-keyscan {{ manager_host }} >> {{ ansible_user_dir }}/.ssh/known_hosts"
-      register: manager_ssh_hostkey
-      until: manager_ssh_hostkey.rc == 0
-      retries: 60
-      delay: 5
-      changed_when: true
-      no_log: true
+        - name: Fetch manager ssh hostkey
+          ansible.builtin.shell: "ssh-keyscan {{ manager_host }} >> {{ ansible_user_dir }}/.ssh/known_hosts"
+          register: manager_ssh_hostkey
+          until: manager_ssh_hostkey.rc == 0
+          retries: 60
+          delay: 5
+          changed_when: true
+          no_log: true
 
-    - name: Wait until ssh public key authentication to the manager works
-      ansible.builtin.command:
-        cmd: >-
-          ssh
-          -i {{ terraform_path }}/.id_rsa.{{ cloud }}
-          -o BatchMode=yes
-          -o ConnectTimeout=5
-          -o PreferredAuthentications=publickey
-          -o StrictHostKeyChecking=yes
-          -o UserKnownHostsFile={{ ansible_user_dir }}/.ssh/known_hosts
-          {{ image_username }}@{{ manager_host }}
-          true
-      register: manager_ssh_auth
-      until: manager_ssh_auth.rc == 0
-      retries: 60
-      delay: 5
-      changed_when: false
+        - name: Wait until ssh public key authentication to the manager works
+          ansible.builtin.command:
+            cmd: >-
+              ssh
+              -i {{ terraform_path }}/.id_rsa.{{ cloud }}
+              -o BatchMode=yes
+              -o ConnectTimeout=5
+              -o PreferredAuthentications=publickey
+              -o StrictHostKeyChecking=yes
+              -o UserKnownHostsFile={{ ansible_user_dir }}/.ssh/known_hosts
+              {{ image_username }}@{{ manager_host }}
+              true
+          register: manager_ssh_auth
+          until: manager_ssh_auth.rc == 0
+          retries: 60
+          delay: 5
+          changed_when: false
+      rescue:
+        # Manager bring-up failed (port 22, host-key scan, or the public-key
+        # probe). When SSH itself is what failed we cannot pull logs over SSH,
+        # but the serial console is reachable out-of-band with the
+        # orchestrator's cloud credentials, and cloud-init writes its
+        # boot/output there. Must run before post.yml's cleanup tears the
+        # manager down.
+        - name: Capture the manager serial console log (no manager SSH required)
+          ansible.builtin.command:
+            chdir: "{{ terraform_path }}"
+            cmd: "{{ ansible_user_dir }}/venv/bin/openstack console log show {{ manager_server_name }}"
+          environment:
+            OS_CLOUD: "{{ cloud }}"
+          register: manager_console_log
+          changed_when: false
+          failed_when: false
+
+        - name: Show the captured manager serial console log
+          ansible.builtin.debug:
+            msg: >-
+              {{ (manager_console_log.stdout_lines | default([]))
+                 + (manager_console_log.stderr_lines | default([])) }}
+
+        - name: Fail the deploy after capturing console diagnostics
+          ansible.builtin.fail:
+            msg: >-
+              Manager bring-up failed at task '{{ ansible_failed_task.name }}':
+              {{ ansible_failed_result.msg | default('see task result above') }}.
+              The serial console log was captured above (task "Show the
+              captured manager serial console log") for diagnosis. If this was
+              the public-key probe, the usual cause is cloud-init not having
+              written the image user's authorized_keys in time.
 
     - name: Get ssh keypair from terraform environment
       ansible.builtin.shell:


### PR DESCRIPTION
## Problem

`testbed-upgrade-stable-ubuntu-24.04` (and other jobs running
`playbooks/deploy.yml`) intermittently fail during manager bring-up at
*Wait until ssh public key authentication to the manager works*: sshd is up
and the host key is scannable, but public-key auth is refused for the whole
retry window. The usual cause is a cloud-init timing race — the image user's
`authorized_keys` has not been written yet.

The hard part is diagnosis. The manager's cloud-init log cannot be pulled over
SSH (SSH is exactly what failed), and `post.yml` then runs `cleanup.py`
unconditionally, destroying the manager — and its console — before anything
reads it. Every occurrence so far has had to be reconstructed from the
orchestrator side only.

Most recent occurrence, which prompted this change (periodic-midnight,
2026-05-29 — 60/60 public-key retries denied, failed at ~8m):
https://zuul.services.osism.tech/t/osism/build/441363899a4446aeb1146da5efb5899e

## What this PR does

Wraps the three readiness probes (port-22 wait, host-key scan, auth probe) in a
`block`, and on failure captures the manager's **serial console log**
out-of-band via `openstack console log show` using the orchestrator's existing
cloud credentials (`OS_CLOUD`) — no manager SSH required. The log is printed
into the job output for triage, then the play re-fails so the build still
reports the failure. The capture runs in the run phase, before the post-run
cleanup tears the manager down.

This is diagnostic instrumentation: the success path is unchanged. The next
time the race fires, the cloud-init console output should show whether
cloud-init stalled or errored, and where.

Notes:
- `manager_server_name` (default `testbed-manager`) is parameterised rather
  than hard-coded.
- The rescue covers all three probes and reports which task actually failed.
- The capture is `failed_when: false` so an instrumentation hiccup cannot mask
  the real failure.

## Earlier work on this problem

- #2887 (*deploy: replace fixed delays with event-driven waits for SSH auth and
  docker*, merged 2026-05-08) added this very probe, replacing a fixed 60s
  pause with a retrying `ssh-keyscan` + active public-key probe so bootstrap
  continues as soon as auth is ready. It absorbs the race when cloud-init
  finishes within the window; this PR adds the diagnostics for when it does not.
- osism/python-osism#2282 (`ANSIBLE_SSH_RETRIES=3`) addressed a related but
  distinct SSH "Permission denied (publickey)" race on the production
  `osism apply` path (a per-task ControlPath cold-burst) — a different
  manifestation, noted here for context.

## Testing

YAML validated locally; full `ansible-lint` / syntax check runs in CI. The
capture path only runs on a real readiness failure, so it is best validated by
the next occurrence (or a forced failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)