### PR TITLE
ansible: drop obsolete osism-fqcn noqa on blocks

### DIFF
--- a/ansible/manager-part-0.yml
+++ b/ansible/manager-part-0.yml
@@ -41,7 +41,7 @@
         repo_path: "{{ result_home.stdout }}/src/github.com"
       when: repo_path is not defined
 
-    - name: Debian/Ubuntu specific tasks  # noqa: osism-fqcn
+    - name: Debian/Ubuntu specific tasks
       when: ansible_os_family == "Debian"
       block:
         - name: Fail if Ubuntu version is lower than 24.04

--- a/ansible/manager-part-3.yml
+++ b/ansible/manager-part-3.yml
@@ -130,7 +130,7 @@
 
   tasks:
     - name: Try to apply the manager role
-      block:  # noqa osism-fqcn
+      block:
         - name: Apply manager role
           ansible.builtin.include_role:
             name: osism.services.manager


### PR DESCRIPTION
Removes two now-unnecessary `# noqa: osism-fqcn` annotations on `block`
constructs in the manager playbooks.

The custom `osism-fqcn` ansible-lint rule previously emitted spurious
violations on `block`/`rescue`/`always` constructs, so these annotations
were added as a workaround. osism/container-images#902 fixes the rule to
correctly skip these constructs, and the updated `ansible-lint` image has
been published (and is consumed as `:latest` by the Zuul lint job), so the
suppressions are no longer needed.

Both suppressions sat on genuine block false-positives:

- `ansible/manager-part-0.yml` — "Debian/Ubuntu specific tasks" block
- `ansible/manager-part-3.yml` — "Try to apply the manager role" block

Note: osism/issues#1368 listed `manager-part-1.yml`, but that file has no
`osism-fqcn` annotation. The actual second annotation lives in
`manager-part-3.yml` (written as `# noqa osism-fqcn`, without the colon).
The issue checklist has been corrected accordingly.

Related-Bug: #1368