### PR TITLE
zuul: move current lane to OpenStack 2025.1

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -191,7 +191,7 @@
       tempest: true
 
 # -----------------------------------------------------------------------------
-# 3.4 "In a Nutshell" Deploy Jobs - Current OpenStack Release (2024.2)
+# 3.4 "In a Nutshell" Deploy Jobs - Current OpenStack Release (2025.1)
 # -----------------------------------------------------------------------------
 
 - job:
@@ -199,7 +199,7 @@
     parent: testbed-deploy-in-a-nutshell-ubuntu-24.04
     vars:
       ceph_version: reef
-      openstack_version: "2024.2"
+      openstack_version: "2025.1"
 
 - job:
     name: testbed-deploy-current-in-a-nutshell-with-tempest-ubuntu-24.04
@@ -303,7 +303,7 @@
       manager_version: 9.5.0
       ceph_version_next: skip
       manager_version_next: latest
-      openstack_version_next: "2024.2"
+      openstack_version_next: "2025.1"
 
 - job:
     name: testbed-upgrade-stable-next-ubuntu-24.04


### PR DESCRIPTION
### What

Move both `current` testbed lanes from OpenStack `2024.2` to `2025.1`:

- `testbed-deploy-current-in-a-nutshell-*` `openstack_version: "2024.2" → "2025.1"`
  (explicit override kept, to insulate the lane against future default drift)
- `testbed-update-stable-current-ubuntu-24.04` `openstack_version_next: "2024.2" → "2025.1"`

### Why

`current` is meant to track the OpenStack release the `latest` dev line ships.
After OSISM `10.0.0` shipped `2025.1` (#2857), the `current` lanes were left on
`2024.2` — now a full release *behind* `stable`. `2024.2` is end-of-life, so
those nightly slots were testing an obsolete release. Nothing exercises 2024.2
after this change.

Both values are actually consumed: the deploy value flows into terraform on a
`latest` manager, and the update value hits the `MANAGER_VERSION == latest`
branch in `upgrade-manager.sh` (so `set-openstack-version.sh` applies it).

### Scope

This is the first step of osism/testbed#2900. The `next` lane bump to `2026.1`
is blocked on 2026.1 support and follows separately. A previously considered
step that bumped the `openstack_version` default in `configuration.yml` was
dropped as a no-op (the value is shadowed in CI and overwritten on documented
installs by `terraform/Makefile`); see #2900 for details.

### Test

`zuul` / `zuul-additional` labels to run the affected `current` lanes against
2025.1.

Refs: osism/testbed#2900
