### PR TITLE
tempest: exclude TempURL with-prefix test

### DIFF
--- a/scripts/check/302-openstack-with-tempest.sh
+++ b/scripts/check/302-openstack-with-tempest.sh
@@ -35,6 +35,21 @@ tempest.api.object_storage.test_object_temp_url.ObjectTempUrlTest.test_head_obje
 tempest.api.object_storage.test_object_temp_url.ObjectTempUrlTest.test_put_object_using_temp_url
 EOF
     fi
+
+    # tempest 46.3.0 added a prefix-scoped TempURL test (temp_url_prefix=),
+    # validated against Swift (tempest Launchpad bug 2142680:
+    # https://bugs.launchpad.net/tempest/+bug/2142680). It is not portable to
+    # RGW: it signs a hardcoded "/v1/<account>/..." path, but the request hits
+    # the storage URL, which RGW serves under rgw_swift_url_prefix ("/swift"),
+    # so RGW validates against "/swift/v1/..." and the signature never matches
+    # (403). The other ObjectTempUrl tests pass because they sign the real
+    # request path (urlparse(base_url).path), not a hardcoded one. Behaviour is
+    # the same on Reef (18.2.8) and Squid (19.2.4) and depends on the /swift
+    # prefix, not the Ceph release; exclude unconditionally until tempest (or
+    # RGW, in rgw_swift_auth.cc PrefixableSignatureHelper) is fixed.
+    cat >> /opt/tempest/exclude.lst << 'EOF'
+tempest.api.object_storage.test_object_temp_url.ObjectTempUrlTest.test_get_object_using_temp_url_with_prefix
+EOF
 fi
 
 _tempest() {


### PR DESCRIPTION
## What

tempest 46.3.0 added
`ObjectTempUrlTest.test_get_object_using_temp_url_with_prefix` (id `a4c34c55`),
a prefix-scoped Swift TempURL test (`temp_url_prefix=`) that did not exist in
46.2.0. When `tempest:latest` picked up 46.3.0, the 2026-06-19 periodic-midnight
`testbed-deploy-current` and `testbed-deploy-next` jobs started failing on it
with 403 AccessDenied.

This adds an unconditional exclusion in
`scripts/check/302-openstack-with-tempest.sh`.

## Root cause: the test is not portable to RGW

A TempURL signature must be computed over the path that is actually requested.
The new test does not do that:

- it signs a **hardcoded** path `"/v1/<account>/<container>/<prefix>"`
  (`account = base_url.split("/")[-1]`);
- but it requests the storage URL, which RGW serves under
  `rgw_swift_url_prefix` (default `/swift`), i.e.
  `/swift/v1/<account>/<container>/<object>`.

RGW validates the signature against the path it receives (`/swift/v1/...`), so
the signed path (missing `/swift`) never matches → 403. The five non-prefix
`ObjectTempUrl` tests pass on RGW because they build the signed path from
`urlparse(base_url).path` (the real request path, including `/swift`) via the
`_get_temp_url` helper — this new test diverged and hardcoded the Swift-only
`/v1/<account>` form, which only equals the request path on vanilla Swift.

So RGW's 403 is correct. The behaviour is identical on Reef (18.2.8) and Squid
(19.2.4) (`git diff v18.2.8 v19.2.4 -- src/rgw/rgw_swift_auth.cc`) and depends
on the non-empty `rgw_swift_url_prefix`, not the Ceph release — hence the
exclusion is unconditional.

## Proper fix (upstream)

- **tempest** (primary): build the prefix signing path from
  `urlparse(base_url).path` like `_get_temp_url`, so it signs the real request
  path and passes on both Swift and RGW.
- **RGW** (optional): extend to the prefix branch the prefix-stripped-path
  leniency it already applies to non-prefix TempURLs
  (`rgw_swift_auth.cc` `PrefixableSignatureHelper`).

Remove this exclusion once either lands.

## Not affected

`testbed-deploy-stable` does not run the `tempest.api.object_storage` batch, so
it never runs this test; its 06-19 failure was an unrelated flaky
shelve/unshelve timeout.

## References

- [tempest Launchpad bug 2142680](https://bugs.launchpad.net/tempest/+bug/2142680) — why the test was added
- ceph/ceph#16370 — RGW prefix TempURL support
- https://tracker.ceph.com/issues/20398

🤖 Generated with [Claude Code](https://claude.com/claude-code)