### PR TITLE
Revert ansible to 11.13.0 (ansible-core 2.18)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==12.2.0
+ansible==11.13.0
 python-gilt==1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible==12.3.0
+ansible==12.2.0
 python-gilt==1.2.3


### PR DESCRIPTION
## Problem

`manager-part-0` fails on the **Sync sources in /opt/src** task with:

```
'Connection' object has no attribute '_new_stdin'
```

`ansible.posix.synchronize` is incompatible with **ansible-core 2.19**,
which removed the `_new_stdin` attribute from the `Connection` object.

The controller was bumped to `ansible==12.3.0` (ansible-core 2.19) by
Renovate (#2794, #2906). This conflicts with the manager venv, which is
explicitly pinned to `ansible-core>=2.18.0,<2.19.0` in
`ansible/manager-part-0.yml`.

## Change

Revert both Renovate bumps, back to `ansible==11.13.0` (ansible-core 2.18):

- Revert #2906 (12.2.0 → 12.3.0)
- Revert #2794 (11.13.0 → 12.x)

This restores compatibility with `ansible.posix.synchronize` and aligns
the controller with the manager venv pin.

## Note

Renovate will likely re-propose the v12 bump. A `major` ignore/pin for
`ansible` in the Renovate config may be needed to keep this stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)