### PR TITLE
zuul: capture glance-api log in post-run

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -58,6 +58,7 @@
     pre-run: playbooks/pre.yml
     run: playbooks/deploy.yml
     post-run:
+      - playbooks/collect-glance-logs.yml
       - playbooks/post.yml
       - name: playbooks/cleanup.yml
         cleanup: true

--- a/playbooks/collect-glance-logs.yml
+++ b/playbooks/collect-glance-logs.yml
@@ -1,0 +1,86 @@
+---
+# Capture the tail of the Glance API log from every testbed host into the job
+# output, so a failing Octavia/Glance image import can be diagnosed.
+#
+# Glance writes its log to a file -- kolla-ansible sets
+# "log_file = /var/log/kolla/glance/glance-api.log" -- and not to the
+# container's stdout, so "docker logs glance_api" does not contain the
+# web-download import error. The image-import step ("osism manage image
+# octavia") only reports that the image is "stuck in queued"; the actual reason
+# (download / qcow2->raw conversion / Ceph write) lives only in the on-host
+# glance-api.log. Capturing it here lets zuul-analyzer (which only consumes the
+# job output) classify the failing stage. See the issue-tracker entry
+# "octavia-stuck-queued".
+#
+# This runs in post-run, before the cleanup play tears the environment down.
+# The orchestrator can only reach the manager directly (the nodes sit on a
+# private network), so we hop through the manager, which fans out to every
+# deployed host. The play is best-effort and must never fail the job.
+- name: Collect Glance API logs play
+  hosts: all
+
+  vars_files:
+    - vars/mappings.yml
+    - vars/repositories.yml
+
+  vars:
+    basepath: "{{ ansible_user_dir }}/src/{{ repositories['testbed']['path'] }}"
+    terraform_path: "{{ basepath }}/terraform"
+    glance_log_tail_lines: 2000
+
+  tasks:
+    - name: Set cloud fact (Zuul deployment)
+      ansible.builtin.set_fact:
+        cloud: "{{ cloud_envs[hostvars[groups['all'][0]]['nodepool']['label']] }}"
+      when: "'nodepool' in hostvars[groups['all'][0]]"
+
+    - name: Set cloud fact (local deployment)
+      ansible.builtin.set_fact:
+        cloud: "{{ testbed_cloud | default('ci') }}"
+      when: "'nodepool' not in hostvars[groups['all'][0]]"
+
+    - name: Read the manager address
+      ansible.builtin.slurp:
+        src: "{{ terraform_path }}/.MANAGER_ADDRESS.{{ cloud }}"
+      register: _glance_manager_address
+      failed_when: false
+
+    - name: Capture the Glance API log from all testbed hosts
+      when: _glance_manager_address.content is defined
+      vars:
+        manager_host: "{{ _glance_manager_address.content | b64decode | trim | split('=') | last | replace('\"', '') }}"
+      ansible.builtin.shell:
+        cmd: |
+          set -o pipefail
+          ssh \
+            -i {{ terraform_path }}/.id_rsa.{{ cloud }} \
+            -o BatchMode=yes \
+            -o ConnectTimeout=10 \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            -o LogLevel=ERROR \
+            dragon@{{ manager_host }} 'bash -s' <<'REMOTE'
+          set -uo pipefail
+          hosts=$(osism get hosts 2>/dev/null | awk -F'|' '/^\|/ {gsub(/^ +| +$/,"",$2); if ($2!="" && $2!="Host" && $2!~/^-+$/) print $2}')
+          for h in $hosts; do
+            echo "===== glance-api.log (tail -n {{ glance_log_tail_lines }}) @ ${h} ====="
+            ssh -o StrictHostKeyChecking=no -o LogLevel=ERROR "${h}" '(sudo -n tail -n {{ glance_log_tail_lines }} /var/log/kolla/glance/glance-api.log || tail -n {{ glance_log_tail_lines }} /var/log/kolla/glance/glance-api.log) 2>/dev/null || echo "(no readable glance-api.log on this host)"'
+            echo
+          done
+          REMOTE
+      args:
+        executable: /bin/bash
+      register: _glance_logs
+      changed_when: false
+      failed_when: false
+
+    # Surface stdout *and* stderr: when the SSH to the manager fails before
+    # producing output, the reason lives in stderr and stdout_lines is an empty
+    # (defined) list, so a plain `default` would not fire. `default(..., true)`
+    # also substitutes the falsy/empty result.
+    - name: Show the captured Glance API log
+      ansible.builtin.debug:
+        msg: >-
+          {{ ((_glance_logs.stdout_lines | default([]))
+              + (_glance_logs.stderr_lines | default([])))
+             | default(['(glance-api.log capture was skipped or produced no output)'], true) }}


### PR DESCRIPTION
## Problem

The nightly testbed lanes intermittently fail when the Octavia Amphora image import gets stuck in Glance's `queued` state (tracked as `octavia-stuck-queued`). The image-import step (`osism manage image octavia`) only reports that the image is *stuck*; the actual reason — web-download, qcow2→raw conversion, or Ceph write — is logged by **glance-api** itself.

kolla-ansible configures glance-api with `log_file = /var/log/kolla/glance/glance-api.log`, so the import error goes to that **on-host file, not the container's stdout**. As a result `docker logs glance_api` does not contain it, and nothing in the published job output reveals the failing stage — so the failure can't be diagnosed from CI logs today.

## Latest occurrence (for reference)

`testbed-upgrade-stable-ubuntu-24.04`, periodic-midnight 2026-06-27 — the import stalled at 05:00 UTC and failed the `Bootstrap services` task (the `.CHECKSUM` fetch returned 200, so this is the Glance import-state face, not the checksum face):

- Build: https://zuul.services.osism.tech/t/osism/build/7b81b6b9e86a4de892a47087a2d23c81
- Logs: https://logs.services.osism.tech/7b8/osism/7b81b6b9e86a4de892a47087a2d23c81/

In `job-output.txt` you can see `... seems stuck in queued state` from the import step — but there is **no glance-api log anywhere in that build's artifacts** (only `job-output.*` and the orchestrator debug files). That missing log is exactly what this PR adds. The prior night (2026-06-26, build `4e26fc42`, `testbed-deploy-stable-in-a-nutshell-with-tempest`) shows the same failure on a different lane.

## Change

Adds a best-effort post-run play (`playbooks/collect-glance-logs.yml`) that captures the tail of `glance-api.log` from every testbed host into the **job output**, so the failing import stage is visible in the published build logs.

- The Zuul orchestrator can only reach the **manager** directly (the nodes are on a private network), so the play hops through the manager and fans out to every host returned by `osism get hosts` — the same shape as the existing `tboperator` container-log collector.
- Runs **before** the cleanup play tears the environment down.
- **Never fails the job:** a missing manager address, an unreachable host, or an unreadable log are all tolerated (`sudo -n` so it can't hang). The final debug surfaces both stdout *and* stderr (with an empty-result fallback) so a failed SSH still shows why.
- Wired into `abstract-testbed-deploy`'s post-run, so every deploy / update / upgrade lane inherits it.

## Validation

- `yamllint` clean; `ansible-lint` passes at the `production` profile.
- `bash -n` on both the local wrapper and the remote (manager-side) heredoc body; host-extraction `awk` checked against a sample `osism get hosts` table.
- Not yet exercised against a live failing build — once it captures a real log, the failing import stage (download / qcow2→raw convert / Ceph write) can be read straight from the build's job output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
