### PR TITLE
manager: overlay generics ansible.cfg via gilt

### DIFF
--- a/gilt.yml
+++ b/gilt.yml
@@ -2,6 +2,8 @@
 - git: https://github.com/osism/generics.git
   version: main
   files:
+    - src: environments/manager/ansible.cfg
+      dst: environments/manager/
     - src: environments/manager/images.yml
       dst: environments/manager/
     - src: src/render-images.py


### PR DESCRIPTION
## Problem

The testbed's `environments/manager/` ships no `ansible.cfg`, unlike every cookiecutter-built deployment, which overlays one from `osism/generics` (it sets `host_key_checking = false`). The `gilt.yml` overlay pulled only `images.yml` and the render/set-versions helpers, leaving the manager environment without an `ansible.cfg`.

This breaks the new `osism update manager` seed-container path (wired in `ansible-collection-services` `f1e7869f`). That path runs `osism.manager.manager` from the `osism/seed` image via `ansible-playbook -i hosts`, with the working directory at `/opt/configuration/environments/manager`. Host-key behaviour there comes solely from a cwd `ansible.cfg`. With none present, Ansible falls back to its default `host_key_checking = True`, so `Apply role manager`'s first SSH to the manager runs strict checking against an empty `known_hosts` and aborts:

```
fatal: [testbed-manager]: UNREACHABLE! => {"changed": false,
  "msg": "Failed to connect to the host via ssh: Host key
  verification failed.", "unreachable": true}
```

failing `testbed-update` at the final re-apply (first seen periodic-midnight build `b842f678`, 2026-06-28). Deploy-time manager apply does not hit this because it runs from the `osism-ansible` image, which bakes `host_key_checking = false`.

## Fix

Overlay `environments/manager/ansible.cfg` from generics like `images.yml`, so the testbed's manager environment matches a standard cookiecutter-built deployment and tracks the single generics source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)