### PR TITLE
manager: make operator key reachable in seed

### DIFF
--- a/environments/secrets.yml
+++ b/environments/secrets.yml
@@ -2,7 +2,7 @@
 ##########################
 # private ssh keys
 
-operator_private_key: "{{ lookup('file', '/home/dragon/.ssh/id_rsa', errors='ignore')|default(lookup('file', '/ansible/secrets/id_rsa.operator', errors='ignore'), true) }}"
+operator_private_key: "{{ lookup('file', '/opt/configuration/environments/secrets/id_rsa.operator', errors='ignore')|default(lookup('file', '/home/dragon/.ssh/id_rsa', errors='ignore'), true)|default(lookup('file', '/ansible/secrets/id_rsa.operator', errors='ignore'), true) }}"
 
 ##########################
 # passwords

--- a/scripts/deploy/000-manager.sh
+++ b/scripts/deploy/000-manager.sh
@@ -54,6 +54,14 @@ fi
 
 cp /home/dragon/.ssh/id_rsa.pub /opt/ansible/secrets/id_rsa.operator.pub
 
+# Make the operator private key reachable inside the osism/seed container.
+# osism update manager runs the keypair play inside the seed container, which
+# bind-mounts only /opt/configuration; the host-path lookups in secrets.yml do
+# not resolve there. Place a copy in the config dir so the lookup finds it.
+mkdir -p /opt/configuration/environments/secrets
+cp /home/dragon/.ssh/id_rsa /opt/configuration/environments/secrets/id_rsa.operator
+chmod 600 /opt/configuration/environments/secrets/id_rsa.operator
+
 # wait for manager service
 if [[ $CEPH_STACK == "ceph-ansible" ]]; then
     wait_for_container_healthy 60 ceph-ansible


### PR DESCRIPTION
## What

Make the operator private key reachable inside the `osism/seed` container
during `osism update manager`, by placing it in the bind-mounted
configuration directory and reading it from there.

## Why

`osism update manager` runs the keypair play inside the `osism/seed`
container (the default `CONTAINER=auto` path on a manager). That container
bind-mounts only `/opt/configuration`, but `environments/secrets.yml`
resolved `operator_private_key` from host paths *outside* the mount
(`/home/dragon/.ssh/id_rsa`, `/ansible/secrets/id_rsa.operator`). Inside
the container the lookup resolved to an empty string, so the keypair play
wrote a zero-byte `id_rsa.operator` and the manager apply failed with an
opaque SSH error:

```
Load key ".../id_rsa.operator": error in libcrypto: unsupported
... Permission denied (publickey).
```

This broke the midnight upgrade/update lanes (all three failed identically
once the seed-container update path became active).

## How

* `scripts/deploy/000-manager.sh` copies `/home/dragon/.ssh/id_rsa` to
  `/opt/configuration/environments/secrets/id_rsa.operator` after the repo
  is synced into `/opt/configuration`, alongside the existing public-key
  copy.
* `environments/secrets.yml` looks up that in-mount path first, keeping the
  two host paths as fallbacks so managers deployed before this change still
  work.

`configuration_directory` is `/opt/configuration` both on the manager host
and as the seed bind-mount, so the absolute path resolves in the seed
container and in the venv/on-manager contexts alike.
`environments/secrets/` is already gitignored, so the key never lands in
git.

This keeps the testbed's existing design (dynamic Nova keypair,
lookup-based `operator_private_key`); it deliberately does not adopt the
production vault-literal model (that is tbng's role).

## Testing

Integration test in the `osism/seed` container against a simulated
`/opt/configuration` mount:

- in-mount key present -> keypair play resolves the new lookup and writes a
  loadable `id_rsa.operator` (`ssh-keygen -y` succeeds)
- in-mount key absent (and no host key) -> lookup resolves empty; pairs with
  the empty-key guard in osism/ansible-playbooks-manager#52

`yamllint` (repo config) and `shellcheck` clean. A full deploy + upgrade on
a real testbed has not been run.

## Related

- osism/ansible-playbooks-manager#52 (defense-in-depth: fail loudly on an empty operator key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)