### PR TITLE
manager: define internal_interface for seed path

### DIFF
--- a/environments/manager/configuration.yml
+++ b/environments/manager/configuration.yml
@@ -45,6 +45,12 @@ flower_enable: true
 flower_traefik: true
 flower_host: flower.testbed.osism.xyz
 
+# NOTE: internal_interface is defined in inventory/group_vars/testbed-managers.yml,
+#       which is not loaded in the reduced manager environment used by the seed
+#       container (osism update manager). Define it here so osism_api_host
+#       resolves in that context. The referenced local fact is installed on the
+#       manager during bootstrap and is available whenever facts are gathered.
+internal_interface: "{{ ansible_local.testbed_network_devices.management }}"
 osism_api_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface]['ipv4']['address'] }}"
 
 ##########################


### PR DESCRIPTION
## Problem

The `osism_api_host` override in the manager environment
(`environments/manager/configuration.yml`) dereferences
`internal_interface`, which is only defined in
`inventory/group_vars/testbed-managers.yml`. The seed-container path
(`osism update manager`) runs the manager play with the reduced
`environments/manager` inventory and extra-var set, which does **not**
load that group_vars file.

As a result `internal_interface` is undefined, `osism_api_host`
collapses to `AnsibleUndefined`, and the first `ipwrap` site in
`docker-compose.yml.j2` raises:

```
AnsibleFilterError: Unrecognized type <class ...AnsibleUndefined> for ipwrap filter <value>
```

failing `TASK [osism.services.manager : Copy docker-compose.yml file]`
during manager upgrades via the seed path, while the orchestrator
deploy path (full inventory) works.

This is the next layer of the seed-path onion after the host-key
(#2916) and operator-key (#2917) fixes, which advanced the play far
enough to reach this template task.

## Fix

Define `internal_interface` in
`environments/manager/configuration.yml`, mirroring the group_vars
definition, so `osism_api_host` resolves in the seed-path variable
context. The referenced local fact
(`ansible_local.testbed_network_devices.management`) is installed on
the manager during bootstrap and is available whenever facts are
gathered, so no additional inventory or fact wiring is required.

This does not affect the orchestrator path, which does not load this
file and keeps using the group_vars definition.