### PR TITLE
check: make key-value store check release-aware

### DIFF
--- a/scripts/check/200-infrastructure.sh
+++ b/scripts/check/200-infrastructure.sh
@@ -3,6 +3,7 @@ set -x
 set -e
 
 source /opt/manager-vars.sh
+source /opt/configuration/scripts/include.sh
 
 packages='libmonitoring-plugin-perl libwww-perl libjson-perl monitoring-plugins-basic mariadb-client'
 
@@ -60,11 +61,18 @@ else
     run_check "RabbitMQ" perl nagios-plugins/check_rabbitmq_cluster --ssl 1 -H api-int.testbed.osism.xyz -u openstack -p password
 fi
 
+# The key-value store switched from redis to valkey at OpenStack 2025.2. Select
+# the active service (same as deploy/upgrade) and read its master password from
+# secrets.yml so the check tracks the deployed service instead of a hardcoded
+# redis-era password.
+key_value_store=$(valkey_or_redis)
+key_value_store_password=$(awk -v k="${key_value_store}_master_password:" '$1 == k {print $2}' /opt/configuration/environments/kolla/secrets.yml)
+
 echo
-echo "# Status of Redis"
+echo "# Status of ${key_value_store^}"
 echo
 
-run_check "Redis" /usr/lib/nagios/plugins/check_tcp -H 192.168.16.10 -p 6379 -A -E -s 'AUTH QHNA1SZRlOKzLADhUd5ZDgpHfQe6dNfr3bwEdY24\r\nPING\r\nINFO replication\r\nQUIT\r\n' -e 'PONG' -e 'role:master' -e 'slave0:ip=192.168.16.1' -e',port=6379' -j
+run_check "${key_value_store^}" /usr/lib/nagios/plugins/check_tcp -H 192.168.16.10 -p 6379 -A -E -s "AUTH ${key_value_store_password}\r\nPING\r\nINFO replication\r\nQUIT\r\n" -e 'PONG' -e 'role:master' -e 'slave0:ip=192.168.16.1' -e',port=6379' -j
 
 popd > /dev/null
 


### PR DESCRIPTION
## What

Make the post-upgrade key-value store check in
`scripts/check/200-infrastructure.sh` release-aware instead of hardcoding a
redis-era check.

## Why

The infrastructure check sweep validated the key-value store with a single
hardcoded line that always spoke redis on `192.168.16.10:6379` using the
redis-era master password. Unlike the MariaDB and RabbitMQ checks in the same
file, it had no release conditional.

At OpenStack 2025.2, upstream kolla-ansible replaced redis with valkey, and the
valkey role uses a **distinct** `valkey_master_password`. After the upgrade the
check's hardcoded redis password fails `AUTH`, `check_tcp` reports an unexpected
response, and the whole build fails on the only non-conditional check in the
file.

First observed on `testbed-upgrade-stable-next-ubuntu-24.04` (periodic-midnight)
build `3c209b90` — the first run in which the redis→valkey upgrade wall cleared
and the check was ever exercised against valkey. Elasticsearch, MariaDB,
Prometheus, and RabbitMQ all passed; the redis check was the sole failure.

## How

- Source `include.sh` and select the active service with `valkey_or_redis()` —
  the same OpenStack-release signal `deploy/200` and `upgrade/200` already use.
- Read the matching `${store}_master_password` from `secrets.yml` instead of
  embedding a literal. Using the single source of truth removes the duplication
  that caused the drift, so the check follows the deployed service and won't
  re-break the next time a password changes.

Port, host, and `INFO replication` expectations are unchanged: valkey preserves
the redis wire format and the testbed topology is the same.

## Verification

- `shellcheck` clean; `bash -n` OK.
- Password extraction confirmed against `secrets.yml`: `redis` resolves to the
  exact value previously hardcoded (redis-era releases unaffected), `valkey`
  resolves to its distinct password.
- Full live valkey `check_tcp` round-trip still needs a
  `testbed-upgrade-stable-next-ubuntu-24.04` run to exercise end-to-end — hence
  draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
