### PR TITLE
scripts: temporarily disable kubernetes deploy/upgrade steps

### DIFF
--- a/scripts/deploy-services.sh
+++ b/scripts/deploy-services.sh
@@ -15,9 +15,6 @@ sh -c '/opt/configuration/scripts/pull-images.sh'
 # deploy helper services
 sh -c '/opt/configuration/scripts/deploy/001-helpers.sh'
 
-# deploy kubernetes
-sh -c '/opt/configuration/scripts/deploy/500-kubernetes.sh'
-
 # deploy infrastructure services
 sh -c '/opt/configuration/scripts/deploy/200-infrastructure.sh'
 

--- a/scripts/upgrade-services.sh
+++ b/scripts/upgrade-services.sh
@@ -15,9 +15,6 @@ SKIP_CEPH_UPGRADE=${SKIP_CEPH_UPGRADE:-false}
 # pull images
 sh -c '/opt/configuration/scripts/pull-images.sh'
 
-# upgrade kubernetes
-sh -c '/opt/configuration/scripts/upgrade/500-kubernetes.sh'
-
 # upgrade infrastructure services
 if [[ $SKIP_OPENSTACK_UPGRADE == "false" ]]; then
     sh -c '/opt/configuration/scripts/upgrade/200-infrastructure.sh'


### PR DESCRIPTION
## Summary
- Remove the kubernetes deploy stage call from `scripts/deploy-services.sh`
- Remove the kubernetes upgrade stage call from `scripts/upgrade-services.sh`

The k3s deployment is currently a tech preview and does not work: the
upgrade playbook jumps directly from Kubernetes 1.32 to 1.36 instead of
upgrading one minor version at a time, which is unsupported per the
[Kubernetes version skew policy](https://kubernetes.io/releases/version-skew-policy/).
Since we do not use k3s ourselves, the stage is disabled for now to keep
the testbed stable, and will be re-enabled once the upgrade path is fixed.

Tracked upstream in osism/osism-kubernetes#313.

## Test plan
- [ ] Run `deploy-services.sh` and confirm it skips the kubernetes stage
- [ ] Run `upgrade-services.sh` and confirm it skips the kubernetes stage