### PR TITLE
scripts: drop clusterapi step while k3s disabled

### DIFF
--- a/scripts/deploy-services.sh
+++ b/scripts/deploy-services.sh
@@ -26,6 +26,3 @@ sh -c '/opt/configuration/scripts/deploy/300-openstack.sh'
 
 # deploy monitoring services
 sh -c '/opt/configuration/scripts/deploy/400-monitoring.sh'
-
-# deploy clusterapi
-sh -c '/opt/configuration/scripts/deploy/510-clusterapi.sh'

--- a/scripts/upgrade-services.sh
+++ b/scripts/upgrade-services.sh
@@ -34,6 +34,3 @@ fi
 if [[ $SKIP_OPENSTACK_UPGRADE == "false" ]]; then
     sh -c '/opt/configuration/scripts/upgrade/400-monitoring.sh'
 fi
-
-# upgrade clusterapi
-sh -c '/opt/configuration/scripts/upgrade/510-clusterapi.sh'


### PR DESCRIPTION
## Problem

`testbed-update-stable-current-ubuntu-24.04` started failing on the
2026-07-09 midnight run (the first run after the commit below merged).
The `Deploy services` task fails rc=2 in `510-clusterapi.sh`: the
`cert_manager` role's first task `Deploy cert-manager crds` aborts with

```
Could not find or access '/share/kubeconfig' on the Ansible Controller.
```

`/share/kubeconfig` is the manager-local k3s / cluster-api management
cluster kubeconfig, produced by `scripts/deploy/500-kubernetes.sh`.

## Root cause

Incomplete removal in:

- osism/testbed@75b9d6c17a631efbfd0a8665bbcd574bbc7f1bc0

That commit disabled the k3s tech preview by dropping the
`500-kubernetes.sh` invocation from `deploy-services.sh` and
`upgrade-services.sh`, but left the `510-clusterapi.sh` invocation in
place. `510-clusterapi.sh` runs `osism apply clusterapi` and the
`cert_manager` play, both of which need the k3s cluster and its
`/share/kubeconfig`. With k3s no longer deployed the kubeconfig is never
written, so cert_manager fails on every run — this is persistent, not a
flake.

## Fix

Remove the `510-clusterapi.sh` invocation from both `deploy-services.sh`
and `upgrade-services.sh` so the k8s tech preview is fully disabled as
intended. It can be restored together with `500-kubernetes.sh` once the
k3s upgrade path is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)