### PR TITLE
deploy: purge stale manager ssh host key

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -127,7 +127,14 @@
             timeout: 300
 
         - name: Fetch manager ssh hostkey
-          ansible.builtin.shell: "ssh-keyscan {{ manager_host }} >> {{ ansible_user_dir }}/.ssh/known_hosts"
+          # Purge any stale entry for this floating IP before scanning. The
+          # orchestrator's known_hosts is persistent and never cleaned, and
+          # ephemeral manager IPs are recycled across builds, so a prior
+          # build's host key can linger ("fossil") and make the strict-check
+          # probe below fail with REMOTE HOST IDENTIFICATION HAS CHANGED.
+          ansible.builtin.shell: >-
+            ssh-keygen -R {{ manager_host }} -f {{ ansible_user_dir }}/.ssh/known_hosts >/dev/null 2>&1;
+            ssh-keyscan {{ manager_host }} >> {{ ansible_user_dir }}/.ssh/known_hosts
           register: manager_ssh_hostkey
           until: manager_ssh_hostkey.rc == 0
           retries: 60


### PR DESCRIPTION
## Problem

A midnight `testbed-deploy-*` build failed after ~11 min at the pre-flight task **"Wait until ssh public key authentication to the manager works"** with:

```
@@@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED @@@
Host key for 81.163.193.194 has changed and you have requested strict checking.
Host key verification failed.
```

The manager VM was healthy (port 22 open, clean serial-console boot). The abort came from a **stale host-key entry** in the orchestrator's persistent `~/.ssh/known_hosts`.

## Root cause

- Managers get an ephemeral floating IP from a pool of ~512 addresses (two /24s) that is **recycled** across builds.
- `Fetch manager ssh hostkey` appended the scanned key blindly (`ssh-keyscan >> ~/.ssh/known_hosts`) and never purged; the orchestrator's `known_hosts` is persistent and never cleaned, so it accumulates (the offending entry was at line 1194).
- Manager host keys are otherwise **stable** across builds, so ordinary IP reuse re-appends an identical entry and passes — reuse alone does not fail. The failure additionally needs a **"fossil"**: an entry recorded with a key that no longer matches what the manager now presents (the manager's key changed at some point after the fossil was written).
- The strict-check probe that turns a stale entry into a hard failure was added 2026-05-08 in 909f2804 (`StrictHostKeyChecking=yes`). Before that, a stale entry was harmless.

This is rare — the failing signature appears in exactly **1 of 10,000+** analyzed builds — but inevitable given the never-pruned file. Other fossils likely still sit in the six orchestrators' `known_hosts` files.

## Fix

Run `ssh-keygen -R <ip>` before `ssh-keyscan` so any stale entry for the IP is removed first. Every manager SSH invocation reads this same default `known_hosts`, so purging it fixes the entire chain (the strict probe, the post-reboot wait, and the bare `ssh` deploy-script tasks) without changing their host-key policy. The compound command's rc is the `ssh-keyscan` result, preserving the existing `until`/`retry` semantics.

## Notes

- Detailed analysis: `~/issues/testbed/deploy-manager-hostkey-fossil-collision.md`.
- zuul-analyzer signature `manager-hostkey-fossil-collision` recognizes future occurrences (kept unlinked so any post-fix recurrence stays visible in triage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)