### PR TITLE
deploy: capture cloud state on manager ssh fail

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -182,6 +182,75 @@
               {{ (manager_console_log.stdout_lines | default([]))
                  + (manager_console_log.stderr_lines | default([])) }}
 
+        # When manager bring-up fails, capture cloud-side state so the
+        # failure is diagnosable from the job log alone (CI credentials are
+        # not otherwise accessible). All queries are read-only, best-effort,
+        # and use the build's own cloud credentials:
+        #   - the floating IP's port_id shows whether it is associated to the
+        #     expected manager port (vs a foreign/absent one);
+        #   - the tenant server/port/FIP inventory surfaces leftover or
+        #     unexpected resources in the shared project;
+        #   - the live host-key fingerprint records which host actually
+        #     answers the manager address (e.g. when the ssh probe reports a
+        #     changed host key).
+        - name: Capture floating IP association for the manager address
+          ansible.builtin.command:
+            chdir: "{{ terraform_path }}"
+            cmd: >-
+              {{ ansible_user_dir }}/venv/bin/openstack
+              floating ip show {{ manager_host }} -f yaml
+          environment:
+            OS_CLOUD: "{{ cloud }}"
+          register: manager_fip_show
+          changed_when: false
+          failed_when: false
+
+        - name: Show the floating IP association
+          ansible.builtin.debug:
+            msg: >-
+              {{ (manager_fip_show.stdout_lines | default([]))
+                 + (manager_fip_show.stderr_lines | default([])) }}
+
+        - name: Capture tenant server, port and floating IP inventory
+          ansible.builtin.command:
+            chdir: "{{ terraform_path }}"
+            cmd: "{{ ansible_user_dir }}/venv/bin/openstack {{ item }}"
+          environment:
+            OS_CLOUD: "{{ cloud }}"
+          loop:
+            - server list --long -f yaml
+            - port list --long -f yaml
+            - floating ip list --long -f yaml
+          register: manager_tenant_inventory
+          changed_when: false
+          failed_when: false
+
+        - name: Show the tenant inventory
+          ansible.builtin.debug:
+            msg: >-
+              {{ (item.stdout_lines | default([]))
+                 + (item.stderr_lines | default([])) }}
+          loop: "{{ manager_tenant_inventory.results }}"
+          loop_control:
+            label: "{{ item.item }}"
+
+        - name: Fingerprint the host key now presented at the manager address
+          ansible.builtin.shell:
+            cmd: >-
+              set -o pipefail;
+              ssh-keyscan -T 5 {{ manager_host }} 2>/dev/null | ssh-keygen -lf -
+          args:
+            executable: /bin/bash
+          register: manager_hostkey_now
+          changed_when: false
+          failed_when: false
+
+        - name: Show the host key fingerprints now presented
+          ansible.builtin.debug:
+            msg: >-
+              {{ (manager_hostkey_now.stdout_lines | default([]))
+                 + (manager_hostkey_now.stderr_lines | default([])) }}
+
         - name: Fail the deploy after capturing console diagnostics
           ansible.builtin.fail:
             msg: >-


### PR DESCRIPTION
## What

Adds read-only cloud-side diagnostics to the manager bring-up **rescue**
block in `playbooks/deploy.yml`. When manager bring-up fails, the rescue path
now captures and prints, using the build's own `OS_CLOUD` credentials:

- `openstack floating ip show <manager address>` — its `port_id` shows
  whether the floating IP is associated to the expected manager port
  (control-plane) vs a correct association that is mis-routed at L2 (stale
  ARP/conntrack).
- `openstack server/port/floating ip list` — leftover or unexpected
  resources in the shared project (e.g. leaked managers).
- a live `ssh-keyscan … | ssh-keygen -lf` fingerprint of the manager address
  — which host actually answered, to compare against the captured
  serial-console host keys.

All tasks are read-only and best-effort (`changed_when`/`failed_when: false`),
run **only** in the rescue path (no overhead on a passing deploy), and need no
CI credential access — the evidence lands in the job log.

## Why (motivation, not scope)

A recurring failure: the ssh probe *"Wait until ssh public key authentication
to the manager works"* aborts with `REMOTE HOST IDENTIFICATION HAS CHANGED`.
Log analysis of two occurrences shows the manager booted **once** with a
stable key and the floating IP reached it correctly early in the probe, yet
the **same** floating IP reached a **different** host by the time the probe
gave up — the FIP is re-routed mid-build to a host that is not the manager
this build booted. Neither a stale `known_hosts` entry nor the purge in the
earlier fix explains that:

- #2928

**We would rather collect more decisive data before attempting another fix.**
The earlier attempt addressed the wrong layer, and guessing again risks doing
the same. The single most decisive datum is the floating IP's `port_id` at
failure time (control-plane mis-association vs L2 mis-routing); these
diagnostics exist to capture it — and related state — from the next
occurrence, so any follow-up fix targets the layer that is actually at fault.
They are general enough to keep long-term.

## Occurrences (Zuul)

- 2026-07-12 `testbed-deploy-next-in-a-nutshell-with-tempest-ubuntu-24.04`:
  https://zuul.services.osism.tech/t/osism/build/af7b9a8f7bf54b7582e4274744a781c4
- 2026-07-15 `testbed-update-stable-current-ubuntu-24.04`:
  https://zuul.services.osism.tech/t/osism/build/2e71da7b41e045b4840a261450ba030c

Both ran on orchestrator `zuul-testbed04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
