### PR TITLE
Retry apt deb: package downloads on transient failures

### DIFF
--- a/environments/custom/playbook-northwatch.yml
+++ b/environments/custom/playbook-northwatch.yml
@@ -94,6 +94,10 @@
       become: true
       ansible.builtin.apt:
         deb: "{{ northwatch_deb_url }}"
+      register: result
+      until: result is succeeded
+      retries: 5
+      delay: 10
       notify: Restart northwatch
 
     - name: Create the Northwatch configuration directory

--- a/environments/custom/playbook-workarounds.yml
+++ b/environments/custom/playbook-workarounds.yml
@@ -118,6 +118,10 @@
       become: true
       ansible.builtin.apt:
         deb: https://github.com/osism/deb-packaging/raw/refs/heads/main/python3-docker/python3-docker_7.1.0-2_all.deb
+      register: result
+      until: result is succeeded
+      retries: 5
+      delay: 10
       when:
         - "ansible_distribution == 'Ubuntu'"
         - "ansible_distribution_version is version('24.04', '>=')"


### PR DESCRIPTION
## What

Add `register`/`until`/`retries`/`delay` to the two `ansible.builtin.apt`
tasks that install a `.deb` directly from a GitHub URL, so a single
transient network stall retries instead of failing the whole run:

- `environments/custom/playbook-workarounds.yml` — `Install python3-docker`
  (from `github.com/osism/deb-packaging`)
- `environments/custom/playbook-northwatch.yml` — `Install the Northwatch
  package` (from a `github.com/B42Labs/northwatch` release)

Each retries up to 5 times with a 10s delay.

## Why

The `python3-docker` install has failed repeatedly in CI (osism/testbed
deploy and upgrade jobs — Jan, Feb, May and Jul 2026), each time as a
transient GitHub transfer stall: `The read operation timed out`, a
urlopen timeout, or a TLS handshake timeout. The task had no retry, so
one stalled connection failed the whole deploy even though the resource
was fine.

In the 2026-07-17 midnight build the identical URL succeeded on 6 of 7
hosts at the exact moment one host timed out, and on all hosts minutes
earlier — clear evidence a retry would have succeeded.

The northwatch task is the identical `apt deb:` construct; it has not
been observed failing, so that change is preventive/consistency
hardening.

This matches the `until`/`retries` idiom already used elsewhere in the
repo (manager ssh waits in `playbooks/deploy.yml`, galaxy install in
`ansible/manager-part-0.yml`).

## Testing

`ansible-lint` (production profile) and `yamllint` pass on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)