### PR TITLE
Revert "Disable hardening (#1249)"

### DIFF
--- a/environments/configuration.yml
+++ b/environments/configuration.yml
@@ -66,10 +66,6 @@ ceph_cluster_fsid: 11111111-1111-1111-1111-111111111111
 ##########################
 # other
 
-# NOTE: Disabling hardening in the testbed to significantly reduce
-#       deployment time.
-enable_hardening: false
-
 # NOTE: Disabling auditd in the testbed to significantly reduce
 #       waste of resources (in the context of CI).
 enable_auditd: false


### PR DESCRIPTION
This reverts commit 4f8c18cbdb11ee592da47cc79e3f06111efd61c3.

Reason for revert: We need to have CI coverage for the hardening role in order to avoid regressions, since it is still enabled for customer deployments.