### PR TITLE
deploy: use osism.commons.still_alive callback by default

### DIFF
--- a/environments/ansible.cfg
+++ b/environments/ansible.cfg
@@ -11,7 +11,7 @@ use_persistent_connections = true
 # use -vvvv to see details" warning message
 force_valid_group_names = ignore
 
-stdout_callback = community.general.yaml
+stdout_callback = osism.commons.still_alive
 
 callbacks_enabled = profile_tasks
 

--- a/scripts/deploy/000-manager.sh
+++ b/scripts/deploy/000-manager.sh
@@ -69,13 +69,6 @@ fi
 
 docker compose --project-directory /opt/manager ps
 
-# use osism.commons.still_alive stdout callback
-if [[ $(semver $MANAGER_VERSION 7.0.0) -ge 0 || $MANAGER_VERSION == "latest" ]]; then
-    # The plugin is available in OSISM >= 7.0.0 and higher. In future, the callback
-    # plugin will be used by default.
-    sed -i "s/community.general.yaml/osism.commons.still_alive/" /opt/configuration/environments/ansible.cfg
-fi
-
 osism apply resolvconf -l testbed-manager
 osism apply sshconfig
 osism apply known-hosts

--- a/scripts/deploy/100-ceph-with-ansible.sh
+++ b/scripts/deploy/100-ceph-with-ansible.sh
@@ -8,13 +8,6 @@ CEPH_VERSION=$(docker inspect --format '{{ index .Config.Labels "de.osism.releas
 
 sh -c '/opt/configuration/scripts/prepare-ceph-configuration.sh'
 
-# The callback plugin is not included in the Pacific image. The plugin is no longer
-# added there because the builds for Pacific are disabled. This callback plugin will
-# therefore not be used during the deployment of Ceph.
-if [[ $MANAGER_VERSION == "latest" && $CEPH_VERSION == "pacific" ]]; then
-    sed -i "s/osism.commons.still_alive/community.general.yaml/" /opt/configuration/environments/ansible.cfg
-fi
-
 if [[ $CEPH_VERSION == "octopus" || $CEPH_VERSION == "pacific" || $CEPH_VERSION == "quincy" ]]; then
     # The rgw zone was added in ceph-ansible Reef
     sed -i '/  "client\.rgw\./{s#{{ rgw_zone }}\.##g}' /opt/configuration/environments/ceph/configuration.yml
@@ -38,9 +31,4 @@ else
     osism apply copy-ceph-keys
     osism apply cephclient
     osism apply ceph-bootstrap-dashboard
-fi
-
-# Once Ceph has been deployed, the callback plugin can be used again.
-if [[ $MANAGER_VERSION == "latest" && $CEPH_VERSION == "pacific" ]]; then
-    sed -i "s/community.general.yaml/osism.commons.still_alive/" /opt/configuration/environments/ansible.cfg
 fi


### PR DESCRIPTION
## Summary
- The `community.general.yaml` stdout callback plugin was removed in `community.general` 12.0.0, superseded by `result_format=yaml` on the `ansible.builtin.default` callback. Deploy runs currently fail immediately with "the plugin has been removed".
- Set `environments/ansible.cfg` to use `osism.commons.still_alive` as the default stdout callback, and drop the now-unneeded `sed` swaps in `000-manager.sh` and `100-ceph-with-ansible.sh` that toggled between the two plugins.

Closes #2938

## Test plan
- [ ] Run a testbed deploy and confirm Ansible output renders via `osism.commons.still_alive` without callback errors
- [ ] Run a Pacific Ceph deploy path and confirm no reference to the removed `community.general.yaml` plugin remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)